### PR TITLE
Use latest version of jFuzzyLogic via custom AI4Work repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,14 +30,14 @@
         <maven.compiler.target>23</maven.compiler.target>
         <java.version>23</java.version>
         <lombok.version>1.18.36</lombok.version>
-        <jFuzzyLogic.version>1.2.1</jFuzzyLogic.version>
+        <jFuzzyLogic.version>2016-07-04</jFuzzyLogic.version>
     </properties>
 
     <repositories>
-        <!-- OW2 repository for accessing jFuzzyLogic dependency -->
+        <!-- Custom repository to get the latest version of jFuzzyLogic -->
         <repository>
-            <id>ow2-public</id>
-            <url>https://repository.ow2.org/nexus/content/repositories/public/</url>
+            <id>ai4work-jFuzzyLogic</id>
+            <url>https://raw.githubusercontent.com/AI4WORK-Project/jFuzzyLogic/mvn-repository</url>
         </repository>
     </repositories>
 

--- a/src/main/java/eu/ai4work/sws/service/RuleEngineService.java
+++ b/src/main/java/eu/ai4work/sws/service/RuleEngineService.java
@@ -34,9 +34,9 @@ public class RuleEngineService {
 
         setInputParametersToFuzzyInterfaceSystem(fuzzyInferenceSystem, slidingDecisionInputParameters);
 
-        fuzzyInferenceSystem.getFuzzyRuleSet().evaluate();
+        fuzzyInferenceSystem.evaluate();
 
-        String resultAsLinguisticTerm = mapFuzzyInferenceResultToLinguisticTerm(fuzzyInferenceSystem.getFuzzyRuleSet().getVariable(SUGGESTED_WORK_SHARING_APPROACH));
+        String resultAsLinguisticTerm = mapFuzzyInferenceResultToLinguisticTerm(fuzzyInferenceSystem.getVariable(SUGGESTED_WORK_SHARING_APPROACH));
 
         return SlidingDecisionResult.valueOf(resultAsLinguisticTerm);
     }
@@ -95,7 +95,7 @@ public class RuleEngineService {
      */
     private void setInputParametersToFuzzyInterfaceSystem(FIS fuzzyInferenceSystem, Map<String, Object> slidingDecisionInputParameters) throws UnknownInputParameterException {
         slidingDecisionInputParameters.forEach((parameterName, parameterValue) -> {
-            Variable fuzzyVariableForParameter = fuzzyInferenceSystem.getFuzzyRuleSet().getVariable(parameterName);
+            Variable fuzzyVariableForParameter = fuzzyInferenceSystem.getVariable(parameterName);
             if (fuzzyVariableForParameter != null) {
                 fuzzyVariableForParameter.setValue(((Number) parameterValue).doubleValue());
             } else {


### PR DESCRIPTION
Changed the dependency to use the latest version of jFuzzyLogic
- based on the source code at https://github.com/pcingola/jFuzzyLogic
- used the date of the latest commit as version number, because no official release of that code version was found
- created a fork of jFuzzyLogic for AI4Work and serving the jar file via the branch `mvn-repository` of that Github repo, see the file in https://github.com/AI4WORK-Project/jFuzzyLogic/tree/mvn-repository/net/sourceforge/jFuzzyLogic/jFuzzyLogic/2016-07-04
