### PR TITLE
Improve the loading of FCL file and parsing FCL file

### DIFF
--- a/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
+++ b/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
@@ -35,12 +35,15 @@ public class FuzzyInferenceSystemInitializer {
             throw new FileNotFoundException("Fuzzy Control Language (FCL) file not found: " + fclRulesFilePath);
         }
 
-        FIS fuzzyInferenceSystem = FIS.load(fuzzyLogicRulesResourceUrl.getPath());
-        if (fuzzyInferenceSystem == null) {
-            throw new InvalidFclFileException("Failed to parse Fuzzy Control Language (FCL) file: " + fclRulesFilePath);
-        }
-        logger.debug("Fuzzy Inference System (FIS) loaded successfully from FCL file: " + fclRulesFilePath);
+        return parseFclFile(fuzzyLogicRulesResourceUrl.getPath());
+    }
 
-        return fuzzyInferenceSystem;
+    private static FIS parseFclFile(String fclRulesFilePath) {
+        try {
+            logger.debug("Parsing a Fuzzy Inference System (FIS) using an FCL file: " + fclRulesFilePath);
+            return FIS.load(fclRulesFilePath);
+        } catch (Exception exception) {
+            throw new InvalidFclFileException("Failed to parse Fuzzy Control Language (FCL) file: " + fclRulesFilePath, exception);
+        }
     }
 }

--- a/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
+++ b/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
@@ -26,8 +26,8 @@ public class FuzzyInferenceSystemInitializer {
      * @throws FileNotFoundException   if the FCL file cannot be found at the specified path.
      * @throws InvalidFclFileException if the FCL file cannot be parsed.
      */
-    @Bean
-    public FIS InitializeFuzzyInferenceSystem() throws FileNotFoundException, InvalidFclFileException {
+    @Bean(name = "fuzzyInferenceSystem")
+    public FIS initializeFuzzyInferenceSystem() throws FileNotFoundException, InvalidFclFileException {
         String fclRulesFilePath = applicationScenarioConfiguration.getFclRulesFilePath();
         URL fuzzyLogicRulesResourceUrl = getClass().getClassLoader().getResource(fclRulesFilePath);
 

--- a/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
+++ b/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
@@ -42,6 +42,5 @@ public class FuzzyInferenceSystemInitializer {
         logger.debug("Fuzzy Inference System (FIS) loaded successfully from FCL file: " + fclRulesFilePath);
 
         return fuzzyInferenceSystem;
-
     }
 }

--- a/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
+++ b/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
@@ -40,7 +40,7 @@ public class FuzzyInferenceSystemInitializer {
 
     private static FIS parseFclFile(String fclRulesFilePath) {
         try {
-            logger.debug("Parsing a Fuzzy Inference System (FIS) using an FCL file: " + fclRulesFilePath);
+            logger.debug("Initializing a Fuzzy Inference System (FIS) based on the FCL file: " + fclRulesFilePath);
             return FIS.load(fclRulesFilePath);
         } catch (Exception exception) {
             throw new InvalidFclFileException("Failed to parse Fuzzy Control Language (FCL) file: " + fclRulesFilePath, exception);

--- a/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
+++ b/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
@@ -14,8 +14,8 @@ import java.net.URL;
 
 @Configuration
 @RequiredArgsConstructor
-public class FuzzyInterfaceSystemConfiguration {
-    private final static Logger logger = LogManager.getLogger(FuzzyInterfaceSystemConfiguration.class);
+public class FuzzyInferenceSystemInitializer {
+    private final static Logger logger = LogManager.getLogger(FuzzyInferenceSystemInitializer.class);
     private final ApplicationScenarioConfiguration applicationScenarioConfiguration;
 
     /**

--- a/src/main/java/eu/ai4work/sws/config/FuzzyInterfaceSystemConfiguration.java
+++ b/src/main/java/eu/ai4work/sws/config/FuzzyInterfaceSystemConfiguration.java
@@ -15,13 +15,14 @@ import java.net.URL;
 @Configuration
 @RequiredArgsConstructor
 public class FuzzyInterfaceSystemConfiguration {
-    private final ApplicationScenarioConfiguration applicationScenarioConfiguration;
     private final static Logger logger = LogManager.getLogger(FuzzyInterfaceSystemConfiguration.class);
+    private final ApplicationScenarioConfiguration applicationScenarioConfiguration;
 
     /**
-     * Initializes a Fuzzy Inference System (FIS) based on the Fuzzy Control Language (FCL) rules file on application startup.
+     * Initializes a Fuzzy Inference System (FIS) based on the Fuzzy Control Language (FCL) rules file.
+     * This process executes on application startup.
      *
-     * @return an initialized FIS object
+     * @return fuzzyInferenceSystem    an initialized FIS object.
      * @throws FileNotFoundException   if the FCL file cannot be found at the specified path.
      * @throws InvalidFclFileException if the FCL file cannot be parsed.
      */
@@ -34,7 +35,7 @@ public class FuzzyInterfaceSystemConfiguration {
             throw new FileNotFoundException("Fuzzy Control Language (FCL) file not found: " + fclRulesFilePath);
         }
 
-        FIS fuzzyInferenceSystem = FIS.load(fuzzyLogicRulesResourceUrl.getPath(), false); // verbose set to 'false' to avoid GUI-related processing
+        FIS fuzzyInferenceSystem = FIS.load(fuzzyLogicRulesResourceUrl.getPath());
         if (fuzzyInferenceSystem == null) {
             throw new InvalidFclFileException("Failed to parse Fuzzy Control Language (FCL) file: " + fclRulesFilePath);
         }

--- a/src/main/java/eu/ai4work/sws/config/FuzzyInterfaceSystemConfiguration.java
+++ b/src/main/java/eu/ai4work/sws/config/FuzzyInterfaceSystemConfiguration.java
@@ -1,0 +1,46 @@
+package eu.ai4work.sws.config;
+
+import eu.ai4work.sws.exception.InvalidFclFileException;
+import lombok.RequiredArgsConstructor;
+import net.sourceforge.jFuzzyLogic.FIS;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileNotFoundException;
+import java.net.URL;
+
+@Configuration
+@RequiredArgsConstructor
+public class FuzzyInterfaceSystemConfiguration {
+    private final ApplicationScenarioConfiguration applicationScenarioConfiguration;
+    private final static Logger logger = LogManager.getLogger(FuzzyInterfaceSystemConfiguration.class);
+
+    /**
+     * Initializes a Fuzzy Inference System (FIS) based on the Fuzzy Control Language (FCL) rules file on application startup.
+     *
+     * @return an initialized FIS object
+     * @throws FileNotFoundException   if the FCL file cannot be found at the specified path.
+     * @throws InvalidFclFileException if the FCL file cannot be parsed.
+     */
+    @Bean
+    public FIS InitializeFuzzyInferenceSystem() throws FileNotFoundException, InvalidFclFileException {
+        String fclRulesFilePath = applicationScenarioConfiguration.getFclRulesFilePath();
+        URL fuzzyLogicRulesResourceUrl = getClass().getClassLoader().getResource(fclRulesFilePath);
+
+        if (fuzzyLogicRulesResourceUrl == null) {
+            throw new FileNotFoundException("Fuzzy Control Language (FCL) file not found: " + fclRulesFilePath);
+        }
+
+        FIS fuzzyInferenceSystem = FIS.load(fuzzyLogicRulesResourceUrl.getPath(), false); // verbose set to 'false' to avoid GUI-related processing
+        if (fuzzyInferenceSystem == null) {
+            throw new InvalidFclFileException("Failed to parse Fuzzy Control Language (FCL) file: " + fclRulesFilePath);
+        }
+        logger.debug("Fuzzy Inference System (FIS) loaded successfully from FCL file: " + fclRulesFilePath);
+
+        return fuzzyInferenceSystem;
+
+    }
+}

--- a/src/main/java/eu/ai4work/sws/exception/GlobalExceptionHandler.java
+++ b/src/main/java/eu/ai4work/sws/exception/GlobalExceptionHandler.java
@@ -26,14 +26,9 @@ public class GlobalExceptionHandler {
         return createErrorResponse(ex, DebugHint.UNKNOWN_INPUT, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(InvalidFclFileException.class)
-    public ResponseEntity<Map<String, Object>> handleInValidFCFileException(InvalidFclFileException ex) {
-        return createErrorResponse(ex, DebugHint.INVALID_FCL_FILE, HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, Object>> handleUnexpectedExceptions(Exception ex) {
-        logger.error(ex.getMessage(), ex);
+        logger.error("An unexpected exception occurred.", ex);
         return createErrorResponse(ex, DebugHint.UNEXPECTED_ERROR, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/eu/ai4work/sws/exception/GlobalExceptionHandler.java
+++ b/src/main/java/eu/ai4work/sws/exception/GlobalExceptionHandler.java
@@ -33,7 +33,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, Object>> handleUnexpectedExceptions(Exception ex) {
-        logger.error(ex);
+        logger.error(ex.toString(), ex);
         return createErrorResponse(ex, DebugHint.UNEXPECTED_ERROR, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/eu/ai4work/sws/exception/GlobalExceptionHandler.java
+++ b/src/main/java/eu/ai4work/sws/exception/GlobalExceptionHandler.java
@@ -33,7 +33,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, Object>> handleUnexpectedExceptions(Exception ex) {
-        logger.error(ex.toString(), ex);
+        logger.error(ex.getMessage(), ex);
         return createErrorResponse(ex, DebugHint.UNEXPECTED_ERROR, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/eu/ai4work/sws/exception/InvalidFclFileException.java
+++ b/src/main/java/eu/ai4work/sws/exception/InvalidFclFileException.java
@@ -1,7 +1,7 @@
 package eu.ai4work.sws.exception;
 
 public class InvalidFclFileException extends RuntimeException {
-    public InvalidFclFileException(String message) {
-        super(message);
+    public InvalidFclFileException(String message, Exception exception) {
+        super(message, exception);
     }
 }

--- a/src/main/java/eu/ai4work/sws/model/DebugHint.java
+++ b/src/main/java/eu/ai4work/sws/model/DebugHint.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum DebugHint {
     UNKNOWN_INPUT("Invalid sliding decision input. Please check the provided parameter and try again"),
     UNEXPECTED_ERROR("An unexpected error occurred. Check the exception message or system logs for more details"),
-    INVALID_FCL_FILE("Failed to parse the FCL file. Please check the file format and syntax");
 
     private final String debugHintMessage;
     DebugHint(String debugHintMessage) {

--- a/src/main/java/eu/ai4work/sws/service/RuleEngineService.java
+++ b/src/main/java/eu/ai4work/sws/service/RuleEngineService.java
@@ -1,37 +1,27 @@
 package eu.ai4work.sws.service;
 
-import eu.ai4work.sws.config.ApplicationScenarioConfiguration;
-import eu.ai4work.sws.exception.InvalidFclFileException;
 import eu.ai4work.sws.model.SlidingDecisionResult;
 import eu.ai4work.sws.exception.UnknownInputParameterException;
 import lombok.RequiredArgsConstructor;
 import net.sourceforge.jFuzzyLogic.FIS;
 import net.sourceforge.jFuzzyLogic.rule.Variable;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 
-import java.io.FileNotFoundException;
-import java.net.URL;
 import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class RuleEngineService {
     private static final String SUGGESTED_WORK_SHARING_APPROACH = "suggestedWorkSharingApproach";
-    private final Logger logger = LogManager.getLogger(RuleEngineService.class);
-    private final ApplicationScenarioConfiguration applicationScenarioConfiguration;
+    private final FIS fuzzyInferenceSystem;
 
     /**
      * Evaluates the rules based on the provided inputs and returns the sliding decision result.
      *
      * @param slidingDecisionInputParameters The input parameters from the sliding decision request.
      * @return SlidingDecisionResult representing the outcome of the sliding decision.
-     * @throws Exception if there is an issue in process of initializing the FCL file or an evaluating the FCL rules.
      */
-    public SlidingDecisionResult applySlidingDecisionRules(Map<String, Object> slidingDecisionInputParameters) throws Exception {
-        FIS fuzzyInferenceSystem = initializeFuzzyInferenceSystem(applicationScenarioConfiguration.getFclRulesFilePath());
-
+    public SlidingDecisionResult applySlidingDecisionRules(Map<String, Object> slidingDecisionInputParameters) {
         setInputParametersToFuzzyInterfaceSystem(fuzzyInferenceSystem, slidingDecisionInputParameters);
 
         fuzzyInferenceSystem.evaluate();
@@ -39,29 +29,6 @@ public class RuleEngineService {
         String resultAsLinguisticTerm = mapFuzzyInferenceResultToLinguisticTerm(fuzzyInferenceSystem.getVariable(SUGGESTED_WORK_SHARING_APPROACH));
 
         return SlidingDecisionResult.valueOf(resultAsLinguisticTerm);
-    }
-
-    /**
-     * Initializes a Fuzzy Inference System (FIS) based on Fuzzy Control Language (FCL) rules file
-     *
-     * @param fclRulesFilePath The file path of the FCL rules file.
-     * @return Initialized FIS object.
-     * @throws FileNotFoundException If the FCL file is not found.
-     * @throws InvalidFclFileException If the FCL file cannot be parsed.
-     */
-    private FIS initializeFuzzyInferenceSystem(String fclRulesFilePath) throws FileNotFoundException, InvalidFclFileException {
-        URL fuzzyLogicRulesResourceUrl = getClass().getClassLoader().getResource(fclRulesFilePath);
-        if (fuzzyLogicRulesResourceUrl == null) {
-            throw new FileNotFoundException("Fuzzy Control Language (FCL) file not found: " + fclRulesFilePath);
-        }
-
-        FIS fuzzyInferenceSystem = FIS.load(fuzzyLogicRulesResourceUrl.getPath(), false); // verbose set to 'false' because to avoid GUI-related processing
-        if (fuzzyInferenceSystem == null) {
-            throw new InvalidFclFileException("Failed to parse Fuzzy Control Language (FCL) file: " + fclRulesFilePath);
-        }
-
-        logger.debug("Successfully initialized FIS from file: {}", fclRulesFilePath);
-        return fuzzyInferenceSystem;
     }
 
     /**

--- a/src/main/java/eu/ai4work/sws/service/RuleEngineService.java
+++ b/src/main/java/eu/ai4work/sws/service/RuleEngineService.java
@@ -22,7 +22,7 @@ public class RuleEngineService {
      * @return SlidingDecisionResult representing the outcome of the sliding decision.
      */
     public SlidingDecisionResult applySlidingDecisionRules(Map<String, Object> slidingDecisionInputParameters) {
-        setInputParametersToFuzzyInterfaceSystem(fuzzyInferenceSystem, slidingDecisionInputParameters);
+        setInputParametersToFuzzyInferenceSystem(fuzzyInferenceSystem, slidingDecisionInputParameters);
 
         fuzzyInferenceSystem.evaluate();
 
@@ -60,7 +60,7 @@ public class RuleEngineService {
      * @param slidingDecisionInputParameters The input parameters from the sliding decision request.
      * @throws UnknownInputParameterException if an input parameter is not recognized by the FIS.
      */
-    private void setInputParametersToFuzzyInterfaceSystem(FIS fuzzyInferenceSystem, Map<String, Object> slidingDecisionInputParameters) throws UnknownInputParameterException {
+    private void setInputParametersToFuzzyInferenceSystem(FIS fuzzyInferenceSystem, Map<String, Object> slidingDecisionInputParameters) throws UnknownInputParameterException {
         slidingDecisionInputParameters.forEach((parameterName, parameterValue) -> {
             Variable fuzzyVariableForParameter = fuzzyInferenceSystem.getVariable(parameterName);
             if (fuzzyVariableForParameter != null) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,3 +2,6 @@
 spring:
   profiles:
     active: logistics
+logging:
+  level:
+    eu.ai4work.sws: debug


### PR DESCRIPTION
This MR includes the following changes

- FCL rule file is loaded and parsed during the application startup time so it "fails early" if loading/parsing does not work.
- Missing logger exception message and exception added in the `src/main/java/eu/ai4work/sws/exception/GlobalExceptionHandler.java`
- Removed the verbose set to `false` in the `FIS fuzzyInferenceSystem = FIS.load(fuzzyLogicRulesResourceUrl.getPath())` because `FIS.load(String fileName)` method already defaults `verbose` to `false`.
- Enable debugging message in the `src/main/resources/application.yml`