### PR TITLE
Refactor: use instance variable fuzzyInferenceSystem directly in methods and some other refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Sliding Work Sharing 
+# Sliding Work Sharing
 
-Sliding Work Sharing (SWS) Management Component of the AI4Work Project.  
+Sliding Work Sharing (SWS) Management Component of the AI4Work Project.
 
-The aim of this software is to support dynamic work sharing between human and machine (especially AI/robots). It can provide decision support regarding the appropriate degree of machine autonomy and the required degree of human involvement, depending on the respective work situation. 
+The aim of this software is to support dynamic work sharing between human and machine (especially AI/robots). It can
+provide decision support regarding the appropriate degree of machine autonomy and the required degree of human
+involvement, depending on the respective work situation.
 
 ---
 
@@ -11,12 +13,14 @@ The aim of this software is to support dynamic work sharing between human and ma
 ### 1. Prerequisites
 
 To build and run the Sliding Work Sharing, the following software is required:
+
 - **Java**: Version 23.
 - **Apache Maven**: Version 3.8.5 or later.
 
 ### 2. Install Dependencies and Build the Application
 
-Open a terminal in the project directory and execute the following command to clean previous build artifacts, install dependencies and build the application:
+Open a terminal in the project directory and execute the following command to clean previous build artifacts, install
+dependencies and build the application:
 
 ```bash
 mvn clean install
@@ -40,7 +44,8 @@ You can test the application using the `curl` command (or using any other HTTP/R
 
 ### Example Request
 
-Execute the following `curl` command in your terminal to request a "sliding decision" via a POST request to the `/sliding-decision` endpoint:
+Execute the following `curl` command in your terminal to request a "sliding decision" via a POST request to
+the `/sliding-decision` endpoint:
 
 ```bash
 curl --request POST \
@@ -56,6 +61,7 @@ curl --request POST \
 ```
 
 ### Example Response
+
 The application will respond with a JSON string similar to the following:
 
 ```json
@@ -70,17 +76,23 @@ The application will respond with a JSON string similar to the following:
   }
 }
 ```
-_Please Note_: The `decisionExplanation` is not shown here for the sake of brevity. An example is described [here](#how-to-read-the-decisionexplanation).  
+
+_Please Note_: The `decisionExplanation` is not shown here for the sake of brevity. An example is
+described [here](#how-to-read-the-decisionexplanation).
 
 ---
 
 ## Demonstration Scenarios
 
-To make this software useful for application in different domains, it can be configured via application-scenario-specific rules. This is explained in the following, based on simplified example scenarios from the AI4Work project's pilot domains:
+To make this software useful for application in different domains, it can be configured via
+application-scenario-specific rules. This is explained in the following, based on simplified example scenarios from the
+AI4Work project's pilot domains:
 
 1. [Logistics Scenario](#logistics-scenario)
 2. [Agriculture Scenario](#agriculture-scenario)
 3. [Construction Scenario](#construction-scenario)
+
+---
 
 ### Logistics Scenario
 
@@ -89,8 +101,8 @@ This example scenario is from the logistics domain:
 - imagine a queue of trucks that deliver material to a warehouse
 - usually the sequence of trucks is "first come, first served"
 - an exception to the previous rule is that a truck should be prioritized if
-  - the stock of some material is getting low
-  - a truck is delivering that very same material
+    - the stock of some material is getting low
+    - a truck is delivering that very same material
 
 The SWS management decides in how far a human should be involved in the decision. This decision depends on:
 
@@ -102,7 +114,8 @@ The SWS management decides in how far a human should be involved in the decision
 - if the queue is short and the truck is near its front, it can be automatically prioritized
 - if the queue is long and the truck is near its end, a human needs to be involved in the decision
 
-To explore the example rules in detail, please refer to the FCL file located [here](src/main/resources/rules/TruckSchedulingSlidingDecisionRules.fcl).
+To explore the example rules in detail, please refer to the FCL file
+located [here](src/main/resources/rules/TruckSchedulingSlidingDecisionRules.fcl).
 
 #### How to Run and Test the Scenario
 
@@ -114,7 +127,8 @@ mvn spring-boot:run -D"spring-boot.run.profiles"=logistics
 
 ##### Example Request
 
-Execute the following `curl` command in your terminal to request a "sliding decision" via a POST request to the `/sliding-decision` endpoint:
+Execute the following `curl` command in your terminal to request a "sliding decision" via a POST request to
+the `/sliding-decision` endpoint:
 
 ```bash
 curl --request POST \
@@ -129,7 +143,9 @@ curl --request POST \
   }'
 ```
 
-To test the implemented rules, you can pass different inputs to the application and observe the outcomes. Just modify the values for the `slidingDecisionInputParameters` as follows:
+To test the implemented rules, you can pass different inputs to the application and observe the outcomes. Just modify
+the values for the `slidingDecisionInputParameters` as follows:
+
 - `noOfTrucksInQueue`: Total number of trucks in the queue (0-20 trucks)
 - `positionOfTruckToBePrioritized`: Position of the truck number that needs to be prioritization (0-20)
 
@@ -149,9 +165,12 @@ The application will respond with a JSON string similar to the following:
   }
 }
 ```
-_Please Note_: The `decisionExplanation` is not shown here for the sake of brevity. An example is described [here](#how-to-read-the-decisionexplanation).
+
+_Please Note_: The `decisionExplanation` is not shown here for the sake of brevity. An example is
+described [here](#how-to-read-the-decisionexplanation).
 
 Depending on the input, the SWS may decide one of the following:
+
 - `AI_AUTONOMOUSLY`: "AI can reschedule without human involvement"
 - `HUMAN_ON_THE_LOOP`: "Human has to be informed about AI's rescheduling"
 - `HUMAN_IN_THE_LOOP`: "Human has to check AI's suggestion"
@@ -168,10 +187,12 @@ This example is from the agriculture domain:
 - carrying the box can be done either by the workers themselves or by an AI-powered transport drone
 - the transport drone has limited capacity, so it cannot transport all boxes for all workers
 
-For each required transport of a harvest box, the SWS management decides in how far a human (either worker or supervisor) should be involved in the decision if this transport should be done by the drone or by the worker. This decision depends on:
+For each required transport of a harvest box, the SWS management decides in how far a human (either worker or
+supervisor) should be involved in the decision if this transport should be done by the drone or by the worker. This
+decision depends on:
 
 - the current waiting time for the drone
-- the fatigue level of the worker 
+- the fatigue level of the worker
 - the distance from the current location of the box to the central collection point
 
 #### Example rules
@@ -180,7 +201,8 @@ For each required transport of a harvest box, the SWS management decides in how 
 - if the distance is high or the waiting time for the drone is low, let the drone carry the box
 - if the waiting time for the drone is high and the fatigue level of the worker is low, let the worker carry the box
 
-To explore the example rules in detail, please refer to the FCL file located [here](src/main/resources/rules/AgricultureSchedulingSlidingDecisionRules.fcl).
+To explore the example rules in detail, please refer to the FCL file
+located [here](src/main/resources/rules/AgricultureSchedulingSlidingDecisionRules.fcl).
 
 #### How to Run and Test the Scenario
 
@@ -192,7 +214,8 @@ mvn spring-boot:run -D"spring-boot.run.profiles"=agriculture
 
 ##### Example Request
 
-Execute the following `curl` command in your terminal to request a "sliding decision" via a POST request to the `/sliding-decision` endpoint:
+Execute the following `curl` command in your terminal to request a "sliding decision" via a POST request to
+the `/sliding-decision` endpoint:
 
 ```bash
 curl --request POST \
@@ -208,12 +231,15 @@ curl --request POST \
 }'
 ```
 
-To test the implemented rules, you can pass different inputs to the application and observe the outcomes. Just modify the values for the `slidingDecisionInputParameters` as follows:
+To test the implemented rules, you can pass different inputs to the application and observe the outcomes. Just modify
+the values for the `slidingDecisionInputParameters` as follows:
+
 - `distanceToCentralCollectionPoint`: The distance to the collection point, measured in meters (0-300 meters)
 - `waitingTimeForDrone`: The time until the drone becomes available, measured in minutes (0-15 minutes)
 - `fatigueLevelOfWorker`: The current fatigue level of the worker, measured in percent (0%-100%)
 
 ##### Example Response
+
 The application will respond with a JSON string similar to the following:
 
 ```json
@@ -228,9 +254,12 @@ The application will respond with a JSON string similar to the following:
   }
 }
 ```
-_Please Note_: The `decisionExplanation` is not shown here for the sake of brevity. An example is described [here](#how-to-read-the-decisionexplanation).
+
+_Please Note_: The `decisionExplanation` is not shown here for the sake of brevity. An example is
+described [here](#how-to-read-the-decisionexplanation).
 
 Depending on the input parameters, the SWS may decide one of the following:
+
 - `AI_AUTONOMOUSLY`: "Let the drone carry the box"
 - `HUMAN_ON_THE_LOOP`: "Inform supervisor, who may potentially intervene"
 - `HUMAN_IN_THE_LOOP`: "Let the worker decide"
@@ -243,12 +272,14 @@ Depending on the input parameters, the SWS may decide one of the following:
 This example scenario is from the construction domain:
 
 - imagine a robot doing work on a construction site
-- while moving, the robot detects an unexpected obstacle in its way (e.g. some construction materials that are stored there temporarily)
+- while moving, the robot detects an unexpected obstacle in its way (e.g. some construction materials that are stored
+  there temporarily)
 - depending on the situation, either of the following may now happen:
-  - the robot may be able to autonomously circumnavigate the obstacle and continue its work
-  - the robot may be blocked and thus unable to continue its work, so that it requires human support
+    - the robot may be able to autonomously circumnavigate the obstacle and continue its work
+    - the robot may be blocked and thus unable to continue its work, so that it requires human support
 
-The SWS management should support the decision if/when a human should be called to help the robot. This decision depends on:
+The SWS management should support the decision if/when a human should be called to help the robot. This decision depends
+on:
 
 - the time that the robot is already blocked
 - the battery status of the robot
@@ -257,10 +288,13 @@ The SWS management should support the decision if/when a human should be called 
 #### Example Rules
 
 - if the battery status of the robot is low, ask for human help
-- if the time the robot is already blocked is short and the battery status of the robot is not low, let the robot continue trying
-- if the time the robot is already blocked is moderate and the battery status of the robot is not low, inform the human about the problem (so that they may decide if/when to help)
+- if the time the robot is already blocked is short and the battery status of the robot is not low, let the robot
+  continue trying
+- if the time the robot is already blocked is moderate and the battery status of the robot is not low, inform the human
+  about the problem (so that they may decide if/when to help)
 
-To explore the example rules in detail, please refer to the FCL file located [here](src/main/resources/rules/ConstructionRobotAssistanceDecisionRules.fcl).
+To explore the example rules in detail, please refer to the FCL file
+located [here](src/main/resources/rules/ConstructionRobotAssistanceDecisionRules.fcl).
 
 #### How to Run and Test the Scenario
 
@@ -272,7 +306,8 @@ mvn spring-boot:run -D"spring-boot.run.profiles"=construction
 
 ##### Example Request
 
-Execute the following `curl` command in your terminal to request a "sliding decision" via a POST request to the `/sliding-decision` endpoint:
+Execute the following `curl` command in your terminal to request a "sliding decision" via a POST request to
+the `/sliding-decision` endpoint:
 
 ```bash
 curl --request POST \
@@ -288,7 +323,9 @@ curl --request POST \
   }'
 ```
 
-To test the implemented rules, you can pass different inputs to the application and observe the outcomes. Just modify the values for the `slidingDecisionInputParameters` as follows:
+To test the implemented rules, you can pass different inputs to the application and observe the outcomes. Just modify
+the values for the `slidingDecisionInputParameters` as follows:
+
 - `timeRobotIsBlocked`: The time that the robot is blocked, measured in minutes (0-15 minutes)
 - `robotBatteryStatus`: The battery status of the robot, measured in percent (0%-100%)
 - `waitingTimeForHuman`: The waiting time for the human to become available, measured in minutes (0-15 minutes)
@@ -309,9 +346,12 @@ The application will respond with a JSON string similar to the following:
   }
 }
 ```
-_Please Note_: The `decisionExplanation` is not shown here for the sake of brevity. An example is described [here](#how-to-read-the-decisionexplanation).
+
+_Please Note_: The `decisionExplanation` is not shown here for the sake of brevity. An example is
+described [here](#how-to-read-the-decisionexplanation).
 
 Depending on the input, the SWS may decide one of the following:
+
 - `AI_AUTONOMOUSLY`: "Let the robot continue trying"
 - `HUMAN_ON_THE_LOOP`: "Inform human about the problem"
 - `HUMAN_IN_THE_LOOP`: "Warn human, but let them decide if/when to help"
@@ -344,11 +384,14 @@ described in the following based on examples.
 }
 ```
 
-- `value`: this is the original number provided as input in the Sliding Decision Request. 
-- `membershipValues`: this shows the "fuzzy categories" into which the input value fits. Each category is assigned a membership degree between 0 and 1. In the given example, the input value of `7.0` might partially belong to both the `LOW` and `MEDIUM` categories with a membership degree of `0.5` each.
+- `value`: this is the original number provided as input in the Sliding Decision Request.
+- `membershipValues`: this shows the "fuzzy categories" into which the input value fits. Each category is assigned a
+  membership degree between 0 and 1. In the given example, the input value of `7.0` might partially belong to both
+  the `LOW` and `MEDIUM` categories with a membership degree of `0.5` each.
 
-### Applied Rules   
-   This field lists the rules that were activated during the decision-making process.
+### Applied Rules
+
+This field lists the rules that were activated during the decision-making process.
 
 ```json
 {
@@ -366,13 +409,16 @@ described in the following based on examples.
 ```
 
 - `name`: an identifier for the rule
-- `condition`:  the part that decides if this rule should be activated, based on the input values' memberships in the fuzzy categories
+- `condition`:  the part that decides if this rule should be activated, based on the input values' memberships in the
+  fuzzy categories
 - `consequence`: the outcome that the rule suggests (e.g., `"[suggestedWorkSharingApproach IS AI_AUTONOMOUSLY]"`)
-- `weight`: is a pre-defined value, which defines the general "importance/impact" of this rule 
-- `degreeOfSupport`: the level of impact that this rule has on the final decision, calculated based on the fuzzy membership degrees of the input values
+- `weight`: is a pre-defined value, which defines the general "importance/impact" of this rule
+- `degreeOfSupport`: the level of impact that this rule has on the final decision, calculated based on the fuzzy
+  membership degrees of the input values
 
 ### Output Variables
-   Shows the final outcome after evaluating all the activated rules.
+
+Shows the final outcome after evaluating all the activated rules.
 
 ```json
 {
@@ -387,7 +433,8 @@ described in the following based on examples.
 }
 ```
 
-- `value`: after combining all contributions from the fired rules, the fuzzy inference process computes a numerical value. In the given example, a value of approximately `2.998` is produced.
+- `value`: after combining all contributions from the fired rules, the fuzzy inference process computes a numerical
+  value. In the given example, a value of approximately `2.998` is produced.
 - `membershipValues`: this final output is then associated with a fuzzy category. In our example, `2.998`
   maps to "HUMAN_ON_THE_LOOP" with a membership degree of `1.0`. This means that, after all rules are applied, the
   final decision is identified as that suggested work sharing approach.

--- a/src/main/java/eu/ai4work/sws/exception/GlobalExceptionHandler.java
+++ b/src/main/java/eu/ai4work/sws/exception/GlobalExceptionHandler.java
@@ -36,7 +36,7 @@ public class GlobalExceptionHandler {
         Map<String, Object> errorDetails = new HashMap<>();
         errorDetails.put(EXCEPTION_NAME, exception.getClass().getName());
         errorDetails.put(EXCEPTION_MESSAGE, exception.getMessage());
-        errorDetails.put(DEBUG_HINT, debugHint.getDebugHintMessage());
+        errorDetails.put(DEBUG_HINT, debugHint);
 
         Map<String, Object> errorResponse = new HashMap<>();
         errorResponse.put(DECISION_STATUS, SlidingDecisionStatus.ERROR);

--- a/src/main/java/eu/ai4work/sws/model/DebugHint.java
+++ b/src/main/java/eu/ai4work/sws/model/DebugHint.java
@@ -1,7 +1,6 @@
 package eu.ai4work.sws.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum DebugHint {
     @JsonProperty("Please check the provided sliding decision input parameter(s) and try again.")

--- a/src/main/java/eu/ai4work/sws/model/DebugHint.java
+++ b/src/main/java/eu/ai4work/sws/model/DebugHint.java
@@ -1,17 +1,11 @@
 package eu.ai4work.sws.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum DebugHint {
-    UNKNOWN_INPUT("Please check the provided sliding decision input parameter(s) and try again."),
-    UNEXPECTED_ERROR("An unexpected error occurred. Check the exception message or system logs for more details");
-
-    private final String debugHintMessage;
-    DebugHint(String debugHintMessage) {
-        this.debugHintMessage = debugHintMessage;
-    }
-    @JsonValue
-    public String getDebugHintMessage() {
-        return debugHintMessage;
-    }
+    @JsonProperty("Please check the provided sliding decision input parameter(s) and try again.")
+    UNKNOWN_INPUT,
+    @JsonProperty("An unexpected error occurred. Check the exception message or system logs for more details")
+    UNEXPECTED_ERROR;
 }

--- a/src/main/java/eu/ai4work/sws/model/SlidingDecisionStatus.java
+++ b/src/main/java/eu/ai4work/sws/model/SlidingDecisionStatus.java
@@ -1,20 +1,13 @@
 package eu.ai4work.sws.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum SlidingDecisionStatus {
-    REQUEST("Sliding Decision Request"),
-    RESPONSE("Sliding Decision Response"),
-    ERROR("Error - Sliding Decision not possible");
-
-    private final String displayName;
-
-    SlidingDecisionStatus(String displayName) {
-        this.displayName = displayName;
-    }
-
-    @JsonValue
-    public String getDisplayName() {
-        return displayName;
-    }
+    @JsonProperty("Sliding Decision Request")
+    REQUEST,
+    @JsonProperty("Sliding Decision Response")
+    RESPONSE,
+    @JsonProperty("Error - Sliding Decision not possible")
+    ERROR;
 }

--- a/src/main/java/eu/ai4work/sws/model/SlidingDecisionStatus.java
+++ b/src/main/java/eu/ai4work/sws/model/SlidingDecisionStatus.java
@@ -1,7 +1,6 @@
 package eu.ai4work.sws.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum SlidingDecisionStatus {
     @JsonProperty("Sliding Decision Request")

--- a/src/main/java/eu/ai4work/sws/service/RuleEngineService.java
+++ b/src/main/java/eu/ai4work/sws/service/RuleEngineService.java
@@ -37,9 +37,9 @@ public class RuleEngineService {
 
         fuzzyInferenceSystem.evaluate();
 
-        String resultAsLinguisticTerm = mapFuzzyInferenceResultToLinguisticTerm(fuzzyInferenceSystem.getVariable(SUGGESTED_WORK_SHARING_APPROACH));
+        String resultAsLinguisticTerm = readFuzzyInferenceResultAsLinguisticTerm();
 
-        SlidingDecisionExplanation decisionExplanation = createSlidingDecisionExplanation();
+        SlidingDecisionExplanation decisionExplanation = readSlidingDecisionExplanationFromFuzzyInferenceSystem();
 
         return new SlidingDecision(SlidingDecisionResult.valueOf(resultAsLinguisticTerm), decisionExplanation);
     }

--- a/src/main/java/eu/ai4work/sws/service/RuleEngineService.java
+++ b/src/main/java/eu/ai4work/sws/service/RuleEngineService.java
@@ -90,12 +90,12 @@ public class RuleEngineService {
     }
 
     /**
-     * Maps a fuzzy inference result to its corresponding linguistic term based on the highest membership degree.
+     * Reads a fuzzy inference result to its corresponding linguistic term based on the highest membership degree.
      *
-     * @param suggestedWorkSharingApproachAsFuzzyVariable The fuzzy output variable to evaluate.
      * @return The output as a linguistic term, i.e., the name of the membership function with the highest membership degree.
      */
-    private String mapFuzzyInferenceResultToLinguisticTerm(Variable suggestedWorkSharingApproachAsFuzzyVariable) {
+    private String readFuzzyInferenceResultAsLinguisticTerm() {
+        Variable suggestedWorkSharingApproachAsFuzzyVariable = fuzzyInferenceSystem.getVariable(SUGGESTED_WORK_SHARING_APPROACH);
         return suggestedWorkSharingApproachAsFuzzyVariable.getLinguisticTerms().entrySet().stream()
                 // Map each linguistic term to its corresponding membership degree
                 .map(linguisticTermWithMembershipDegree -> Map.entry(
@@ -122,11 +122,11 @@ public class RuleEngineService {
     }
 
     /**
-     * Creates the explanation for the sliding decision.
+     * Reads the explanation for the sliding decision.
      *
      * @return SlidingDecisionExplanation containing explanation of the input variables, applied rules and output variables.
      */
-    private SlidingDecisionExplanation createSlidingDecisionExplanation() {
+    private SlidingDecisionExplanation readSlidingDecisionExplanationFromFuzzyInferenceSystem() {
         var functionBlock = fuzzyInferenceSystem.getFunctionBlock(null); // selects the default function block
         return new SlidingDecisionExplanation(extractFuzzyVariableExplanation(functionBlock, Variable::isInput),
                 getAppliedRules(functionBlock),

--- a/src/main/java/eu/ai4work/sws/service/RuleEngineService.java
+++ b/src/main/java/eu/ai4work/sws/service/RuleEngineService.java
@@ -31,15 +31,15 @@ public class RuleEngineService {
      * @return SlidingDecision containing the result and the explanation of the sliding decision.
      */
     public SlidingDecision applySlidingDecisionRules(Map<String, Object> slidingDecisionInputParameters) {
-        verifySlidingDecisionInputParameters(fuzzyInferenceSystem, slidingDecisionInputParameters);
+        verifySlidingDecisionInputParameters(slidingDecisionInputParameters);
 
-        setInputParametersToFuzzyInferenceSystem(fuzzyInferenceSystem, slidingDecisionInputParameters);
+        setInputParametersToFuzzyInferenceSystem(slidingDecisionInputParameters);
 
         fuzzyInferenceSystem.evaluate();
 
         String resultAsLinguisticTerm = mapFuzzyInferenceResultToLinguisticTerm(fuzzyInferenceSystem.getVariable(SUGGESTED_WORK_SHARING_APPROACH));
 
-        SlidingDecisionExplanation decisionExplanation = createSlidingDecisionExplanation(fuzzyInferenceSystem);
+        SlidingDecisionExplanation decisionExplanation = createSlidingDecisionExplanation();
 
         return new SlidingDecision(SlidingDecisionResult.valueOf(resultAsLinguisticTerm), decisionExplanation);
     }
@@ -47,13 +47,12 @@ public class RuleEngineService {
     /**
      * Checks if any required sliding decision input parameters are unknown or missing.
      *
-     * @param fuzzyInferenceSystem           The FIS instance to get the required input parameters.
      * @param slidingDecisionInputParameters The input parameters from the sliding decision request.
      * @throws InvalidInputParameterException if one or more input parameters are unknown or missing.
      */
-    private void verifySlidingDecisionInputParameters(FIS fuzzyInferenceSystem, Map<String, Object> slidingDecisionInputParameters)
+    private void verifySlidingDecisionInputParameters(Map<String, Object> slidingDecisionInputParameters)
             throws InvalidInputParameterException {
-        List<String> requiredParameters = getRequiredInputParametersFromFIS(fuzzyInferenceSystem);
+        List<String> requiredParameters = getRequiredInputParametersFromFIS();
         Set<String> providedParameters = slidingDecisionInputParameters.keySet();
 
         // detect provided input parameters that are not required
@@ -78,7 +77,7 @@ public class RuleEngineService {
         }
     }
 
-    private List<String> getRequiredInputParametersFromFIS(FIS fuzzyInferenceSystem) {
+    private List<String> getRequiredInputParametersFromFIS() {
         return fuzzyInferenceSystem.getFunctionBlock(null)  // Get default function block
                 // get all variables
                 .getVariables().values().stream()
@@ -115,13 +114,11 @@ public class RuleEngineService {
     /**
      * Sets input parameters to the Fuzzy Inference System (FIS).
      *
-     * @param fuzzyInferenceSystem           The FIS instance where input parameters will be set.
      * @param slidingDecisionInputParameters The input parameters from the sliding decision request.
      */
-    private void setInputParametersToFuzzyInferenceSystem(FIS fuzzyInferenceSystem, Map<String, Object> slidingDecisionInputParameters) {
-        slidingDecisionInputParameters.forEach((parameterName, parameterValue) -> {
-            fuzzyInferenceSystem.getVariable(parameterName).setValue(((Number) parameterValue).doubleValue());
-        });
+    private void setInputParametersToFuzzyInferenceSystem(Map<String, Object> slidingDecisionInputParameters) {
+        slidingDecisionInputParameters.forEach((parameterName, parameterValue) ->
+                fuzzyInferenceSystem.getVariable(parameterName).setValue(((Number) parameterValue).doubleValue()));
     }
 
     /**
@@ -129,7 +126,7 @@ public class RuleEngineService {
      *
      * @return SlidingDecisionExplanation containing explanation of the input variables, applied rules and output variables.
      */
-    private SlidingDecisionExplanation createSlidingDecisionExplanation(FIS fuzzyInferenceSystem) {
+    private SlidingDecisionExplanation createSlidingDecisionExplanation() {
         var functionBlock = fuzzyInferenceSystem.getFunctionBlock(null); // selects the default function block
         return new SlidingDecisionExplanation(extractFuzzyVariableExplanation(functionBlock, Variable::isInput),
                 getAppliedRules(functionBlock),


### PR DESCRIPTION
close #24 

The following changes were made in this PR

- used instance variable `fuzzyInferenceSystem` directly in methods
- formated the `README`
- used `JsonProperty` instead of the `JsonValue`
