### PR TITLE
Allow customization to other application scenarios via FCL files that are not part of this repository 

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ your own application scenario, follow these steps:
 
 #### Create your custom `.fcl` file
 
-- `fcl` (fuzzy control language) is used to define input parameters and decision rules. 
+- `fcl` (fuzzy control language) is used to define input parameters and decision rules.
 - suggestion would be to take one of the existing `.fcl` file as template and adjust "the input parameters" and "
   decision rules" to your scenario
 - existing `.fcl` files can be found at [src/main/resources/rules](src/main/resources/rules)
@@ -107,18 +107,19 @@ your own application scenario, follow these steps:
 ### 2. Download the SWS `jar` file
 
 - visit the https://github.com/AI4WORK-Project/sliding-work-sharing/releases release page of repository
-- find the latest release and download the `jar` file named in format `sliding-work-sharing-{version-number}.jar` under the "Assets" list 
+- find the latest release and download the `jar` file named in format `sliding-work-sharing-{version-number}.jar` under
+  the "Assets" list
 - after download completes, the `jar` file can be found in your download folder
 
 ### 3. Run the application using your custom configuration
 
 - place the following files in a single directory
-  - your custom `.fcl` file
-  - your custom `.yml` file
-  - the downloaded JAR file (e.g.,`sliding-work-sharing-0.0.1.jar`)  
-  
+    - your custom `.fcl` file
+    - your custom `.yml` file
+    - the downloaded JAR file (e.g.,`sliding-work-sharing-0.0.1.jar`)
+
 _Note_: Ensure the `fclRulesFilePath` is correctly specified in this `.fcl` file
-  
+
 - next, open a terminal in the same directory (where all files are located) and run the following command
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ described [here](#how-to-read-the-decisionexplanation).
 
 ## How to apply the SWS to your own application scenario
 
-To apply SWS to
-your own application scenario, you need to do the following:
+To apply SWS to your own application scenario, you need to do the following:
 - define your own input parameters and decision rules in an `.fcl` file
 - create your custom `.yml` configuration file
 - download a runnable version of the software (or build it yourself)
@@ -95,15 +94,15 @@ your own application scenario, you need to do the following:
 
 - `fcl` (fuzzy control language) is used to define input parameters and decision rules.
 - our suggestion would be to take one of the existing `.fcl` file as template and adjust it to your scenario
-  decision rules" to your scenario
+  decision rules to your scenario
 - existing `.fcl` files can be found at [src/main/resources/rules](src/main/resources/rules)
 
 ### Create your custom `.yml` configuration file
 
-- suggestion would be to take an existing `application-{existing-configration}.yml` as template and adjust
+- suggestion would be to take an existing `application-{existing-configuration}.yml` as template and adjust
   the `fclRulesFilePath` to your `.fcl` file and also the textual description of the sliding decision approaches so that
   they fit to your scenario
-- replace the `{existing-configration}` with a name representing your custom scenario
+- replace the `{existing-configuration}` with a name representing your custom scenario
 - existing configuration files (`.yml`) can be found at [src/main/resources](src/main/resources)
 
 ### Download (or build) the sliding-work-sharing `.jar` file
@@ -112,7 +111,7 @@ your own application scenario, you need to do the following:
   https://github.com/AI4WORK-Project/sliding-work-sharing/releases/download/v0.1.0/sliding-work-sharing-0.1.0.jar
 - alternatively, in case you prefer to build your own jar file, follow the [instructions above](#how-to-build-and-run-the-application)
 
-### 3. Run the application using your custom configuration
+### Run the application using your custom configuration
 
 - place the following files in a single directory
     - your custom `.fcl` file
@@ -124,10 +123,10 @@ _Note_: Ensure that the path to your `.fcl` file is correctly specified as `fclR
 - next, open a terminal in the same directory (where all files are located) and run the following command
 
 ```bash
-java -jar .\sliding-work-sharing-0.1.0.jar --spring.config.location=application-{your-configration-name}.yml
+java -jar sliding-work-sharing-0.1.0.jar --spring.config.location=application-{your-configuration-name}.yml
 ```
 
-_Please Note_: here the `{your-configration-name}` would be the name your custom scenario's name
+_Please Note_: here the `{your-configuration-name}` would be the name of your custom scenario's name
 
 To test your custom scenario, refer the example of testing the application section [here](#how-to-test-the-application)
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ your own application scenario, follow these steps:
 ### 2. Download the SWS `jar` file
 
 - visit the https://github.com/AI4WORK-Project/sliding-work-sharing/releases release page of repository
-- download the latest `jar` file named in format `sliding-work-sharing-{version-number}.jar` 
+- find the latest release and download the `jar` file named in format `sliding-work-sharing-{version-number}.jar` under the "Assets" list 
 - after download completes, the `jar` file can be found in your download folder
 
 ### 3. Run the application using your custom configuration

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ described [here](#how-to-read-the-decisionexplanation).
 
 ## How to apply the SWS to your own application scenario
 
-It allows running SWS with configurations that are not included in this repository. To apply Sliding Work Sharing to
+It allows running SWS with configurations that are not included in this repository. To apply SWS to
 your own application scenario, follow these steps:
 
 ### 1. Create Custom `.fcl` file and `application.yml`
@@ -104,32 +104,25 @@ your own application scenario, follow these steps:
 - replace the `{existing-configration}` with a name representing your custom scenario
 - existing configuration files (`.yml`) can be found at [src/main/resources](src/main/resources)
 
-### 2. How to run your custom application scenario
+### 2. Download the SWS `jar` file
 
-#### Build the SWS `jar` file
+- visit the https://github.com/AI4WORK-Project/sliding-work-sharing/releases release page of repository
+- download the latest `jar` file named in format `sliding-work-sharing-{version-number}.jar` 
+- after download completes, the `jar` file can be found in your download folder
 
-- open a terminal in the project directory and execute the following command to clean previous build artifacts and
-  package the application into `jar` file
-
-```bash
-mvn clean package
-```
-
-- after successful build, the `jar` file can be found at the `target/sliding-work-sharing-0.0.1-SNAPSHOT.jar`
-
-#### Run the application using your custom configuration
+### 3. Run the application using your custom configuration
 
 - place the following files in a single directory
   - your custom `.fcl` file
   - your custom `.yml` file
-  - the JAR file `sliding-work-sharing-0.0.1-SNAPSHOT.jar`  
+  - the downloaded JAR file (e.g.,`sliding-work-sharing-0.0.1.jar`)  
   
 _Note_: Ensure the `fclRulesFilePath` is correctly specified in this `.fcl` file
   
 - next, open a terminal in the same directory (where all files are located) and run the following command
 
 ```bash
-java -jar .\sliding-work-sharing-0.0.1-SNAPSHOT.jar --spring.config.location=application-{your-configration-name}.yml
+java -jar .\sliding-work-sharing-0.1.0.jar --spring.config.location=application-{your-configration-name}.yml
 ```
 
 _Please Note_: here the `{your-configration-name}` would be the name your custom scenario's name

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ your own application scenario, follow these steps:
 
 ### 2. Download the SWS `.jar` file
 
-- download the `.jar` file from the following link: https://github.com/AI4WORK-Project/sliding-work-sharing/releases/download/v0.1.0/sliding-work-sharing-0.1.0.jar
+- download the `.jar` file from the following link: 
+  https://github.com/AI4WORK-Project/sliding-work-sharing/releases/download/v0.1.0/sliding-work-sharing-0.1.0.jar
 - after download complete, the `.jar` file can be found in your download folder
 
 ### 3. Run the application using your custom configuration

--- a/README.md
+++ b/README.md
@@ -84,19 +84,21 @@ described [here](#how-to-read-the-decisionexplanation).
 
 ## How to apply the SWS to your own application scenario
 
-It allows running SWS with configurations that are not included in this repository. To apply SWS to
-your own application scenario, follow these steps:
+To apply SWS to
+your own application scenario, you need to do the following:
+- define your own input parameters and decision rules in an `.fcl` file
+- create your custom `.yml` configuration file
+- download a runnable version of the software (or build it yourself)
 
-### 1. Create Custom `.fcl` file and `application.yml`
 
-#### Create your custom `.fcl` file
+### Create your custom `.fcl` file
 
 - `fcl` (fuzzy control language) is used to define input parameters and decision rules.
-- suggestion would be to take one of the existing `.fcl` file as template and adjust "the input parameters" and "
+- our suggestion would be to take one of the existing `.fcl` file as template and adjust it to your scenario
   decision rules" to your scenario
 - existing `.fcl` files can be found at [src/main/resources/rules](src/main/resources/rules)
 
-#### Create your custom `application.yml` file
+### Create your custom `.yml` configuration file
 
 - suggestion would be to take an existing `application-{existing-configration}.yml` as template and adjust
   the `fclRulesFilePath` to your `.fcl` file and also the textual description of the sliding decision approaches so that
@@ -104,20 +106,20 @@ your own application scenario, follow these steps:
 - replace the `{existing-configration}` with a name representing your custom scenario
 - existing configuration files (`.yml`) can be found at [src/main/resources](src/main/resources)
 
-### 2. Download the SWS `.jar` file
+### Download (or build) the sliding-work-sharing `.jar` file
 
 - download the `.jar` file from the following link: 
   https://github.com/AI4WORK-Project/sliding-work-sharing/releases/download/v0.1.0/sliding-work-sharing-0.1.0.jar
-- after download complete, the `.jar` file can be found in your download folder
+- alternatively, in case you prefer to build your own jar file, follow the [instructions above](#how-to-build-and-run-the-application)
 
 ### 3. Run the application using your custom configuration
 
 - place the following files in a single directory
     - your custom `.fcl` file
     - your custom `.yml` file
-    - the downloaded `.jar` file (e.g.,`sliding-work-sharing-0.0.1.jar`)
+    - the `.jar` file (e.g.,`sliding-work-sharing-0.1.0.jar`)
 
-_Note_: Ensure the `fclRulesFilePath` is correctly specified in this `.fcl` file
+_Note_: Ensure that the path to your `.fcl` file is correctly specified as `fclRulesFilePath` in the `.yml` file
 
 - next, open a terminal in the same directory (where all files are located) and run the following command
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,11 @@ mvn clean package
 - place the following files in a single directory
   - your custom `.fcl` file
   - your custom `.yml` file
-  - the JAR file `sliding-work-sharing-0.0.1-SNAPSHOT.jar`
-- now, open a terminal in that directory and run
+  - the JAR file `sliding-work-sharing-0.0.1-SNAPSHOT.jar`  
+  
+_Note_: Ensure the `fclRulesFilePath` is correctly specified in this `.fcl` file
+  
+- next, open a terminal in the same directory (where all files are located) and run the following command
 
 ```bash
 java -jar .\sliding-work-sharing-0.0.1-SNAPSHOT.jar --spring.config.location=application-{your-configration-name}.yml

--- a/README.md
+++ b/README.md
@@ -104,19 +104,17 @@ your own application scenario, follow these steps:
 - replace the `{existing-configration}` with a name representing your custom scenario
 - existing configuration files (`.yml`) can be found at [src/main/resources](src/main/resources)
 
-### 2. Download the SWS `jar` file
+### 2. Download the SWS `.jar` file
 
-- visit the https://github.com/AI4WORK-Project/sliding-work-sharing/releases release page of repository
-- find the latest release and download the `jar` file named in format `sliding-work-sharing-{version-number}.jar` under
-  the "Assets" list
-- after download completes, the `jar` file can be found in your download folder
+- download the `.jar` file from the following link: https://github.com/AI4WORK-Project/sliding-work-sharing/releases/download/v0.1.0/sliding-work-sharing-0.1.0.jar
+- after download complete, the `.jar` file can be found in your download folder
 
 ### 3. Run the application using your custom configuration
 
 - place the following files in a single directory
     - your custom `.fcl` file
     - your custom `.yml` file
-    - the downloaded JAR file (e.g.,`sliding-work-sharing-0.0.1.jar`)
+    - the downloaded `.jar` file (e.g.,`sliding-work-sharing-0.0.1.jar`)
 
 _Note_: Ensure the `fclRulesFilePath` is correctly specified in this `.fcl` file
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To apply SWS to your own application scenario, you need to do the following:
 - our suggestion would be to take an existing `application-{existing-configuration}.yml` as template and adjust it:
   - the `fclRulesFilePath` should point to the location of your `.fcl` file
   - the textual description of the decision results should fit to your scenario
-- replace the `{existing-configuration}` with a name representing your custom scenario
+  - replace `{existing-configuration}` with a name representing your custom scenario
 - existing example configuration files can be found at [src/main/resources](src/main/resources)
 
 ### Download (or build) the sliding-work-sharing `.jar` file

--- a/README.md
+++ b/README.md
@@ -93,21 +93,20 @@ To apply SWS to your own application scenario, you need to do the following:
 ### Create your custom `.fcl` file
 
 - `fcl` (fuzzy control language) is used to define input parameters and decision rules.
-- our suggestion would be to take one of the existing `.fcl` file as template and adjust it to your scenario
-  decision rules to your scenario
-- existing `.fcl` files can be found at [src/main/resources/rules](src/main/resources/rules)
+- our suggestion would be to take one of the existing `.fcl` files as template and adjust it to your scenario
+- existing example `.fcl` files can be found at [src/main/resources/rules](src/main/resources/rules)
 
 ### Create your custom `.yml` configuration file
 
-- suggestion would be to take an existing `application-{existing-configuration}.yml` as template and adjust
-  the `fclRulesFilePath` to your `.fcl` file and also the textual description of the sliding decision approaches so that
-  they fit to your scenario
+- our suggestion would be to take an existing `application-{existing-configuration}.yml` as template and adjust it:
+  - the `fclRulesFilePath` should point to the location of your `.fcl` file
+  - the textual description of the decision results should fit to your scenario
 - replace the `{existing-configuration}` with a name representing your custom scenario
-- existing configuration files (`.yml`) can be found at [src/main/resources](src/main/resources)
+- existing example configuration files can be found at [src/main/resources](src/main/resources)
 
 ### Download (or build) the sliding-work-sharing `.jar` file
 
-- download the `.jar` file from the following link:
+- the easiest way is to download the release `.jar` file from the following link:
   https://github.com/AI4WORK-Project/sliding-work-sharing/releases/download/v0.1.0/sliding-work-sharing-0.1.0.jar
 - alternatively, in case you prefer to build your own jar file, follow
   the [instructions above](#how-to-build-and-run-the-application)
@@ -129,7 +128,8 @@ java -jar sliding-work-sharing-0.1.0.jar --spring.config.location=application-{y
 
 _Please Note_: here the `{your-configuration-name}` would be the name of your custom scenario's name
 
-To test your custom scenario, refer the example of testing the application section [here](#how-to-test-the-application)
+To test your custom scenario, follow the example in the [testing the application](#how-to-test-the-application)
+section and adjust its input parameters to fit to your own scenario.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ your own application scenario, follow these steps:
 
 #### Create your custom `.fcl` file
 
+- `fcl` (fuzzy control language) is used to define input parameters and decision rules. 
 - suggestion would be to take one of the existing `.fcl` file as template and adjust "the input parameters" and "
   decision rules" to your scenario
 - existing `.fcl` files can be found at [src/main/resources/rules](src/main/resources/rules)
@@ -99,7 +100,7 @@ your own application scenario, follow these steps:
 
 - suggestion would be to take an existing `application-{existing-configration}.yml` as template and adjust
   the `fclRulesFilePath` to your `.fcl` file and also the textual description of the sliding decision approaches so that
-  they fit your scenario
+  they fit to your scenario
 - replace the `{existing-configration}` with a name representing your custom scenario
 - existing configuration files (`.yml`) can be found at [src/main/resources](src/main/resources)
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,58 @@ _Please Note_: The `decisionExplanation` is not shown here for the sake of brevi
 
 ---
 
+## How to apply the SWS to your own application scenario
+
+It allows running SWS with configurations that are not included in this repository. To apply Sliding Work Sharing to
+your own application scenario, follow these steps:
+
+### 1. Create Custom `.fcl` file and `application.yml`
+
+#### Create your custom `.fcl` file
+
+- suggestion would be to take one of the existing `.fcl` file as template and adjust "the input parameters" and "
+  decision rules" to your scenario
+- existing `.fcl` files can be found at [src/main/resources/rules](src/main/resources/rules)
+
+#### Create your custom `application.yml` file
+
+- suggestion would be to take an existing `application-{existing-configration}.yml` as template and adjust
+  the `fclRulesFilePath` to your `.fcl` file and also the textual description of the sliding decision approaches so that
+  they fit your scenario
+- replace the `{existing-configration}` with a name representing your custom scenario
+- existing configuration files (`.yml`) can be found at [src/main/resources](src/main/resources)
+
+### 2. How to run your custom application scenario
+
+#### Build the SWS `jar` file
+
+- open a terminal in the project directory and execute the following command to clean previous build artifacts and
+  package the application into `jar` file
+
+```bash
+mvn clean package
+```
+
+- after successful build, the `jar` file can be found at the `target/sliding-work-sharing-0.0.1-SNAPSHOT.jar`
+
+#### Run the application using your custom configuration
+
+- place the following files in a single directory
+  - your custom `.fcl` file
+  - your custom `.yml` file
+  - the JAR file `sliding-work-sharing-0.0.1-SNAPSHOT.jar`
+- now, open a terminal in that directory and run
+
+```bash
+java -jar .\sliding-work-sharing-0.0.1-SNAPSHOT.jar --spring.config.location=application-{your-configration-name}.yml
+```
+
+_Please Note_: here the `{your-configration-name}` would be the name your custom scenario's name
+
+To test your custom scenario, refer the example of testing the application section [here](#how-to-test-the-application)
+
+---
+
 ## Demonstration Scenarios
 
 To make this software useful for application in different domains, it can be configured via application-scenario-specific rules. This is explained in the following, based on simplified example scenarios from the AI4Work project's pilot domains:

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ described [here](#how-to-read-the-decisionexplanation).
 ## How to apply the SWS to your own application scenario
 
 To apply SWS to your own application scenario, you need to do the following:
+
 - define your own input parameters and decision rules in an `.fcl` file
 - create your custom `.yml` configuration file
 - download a runnable version of the software (or build it yourself)
-
 
 ### Create your custom `.fcl` file
 
@@ -107,9 +107,10 @@ To apply SWS to your own application scenario, you need to do the following:
 
 ### Download (or build) the sliding-work-sharing `.jar` file
 
-- download the `.jar` file from the following link: 
+- download the `.jar` file from the following link:
   https://github.com/AI4WORK-Project/sliding-work-sharing/releases/download/v0.1.0/sliding-work-sharing-0.1.0.jar
-- alternatively, in case you prefer to build your own jar file, follow the [instructions above](#how-to-build-and-run-the-application)
+- alternatively, in case you prefer to build your own jar file, follow
+  the [instructions above](#how-to-build-and-run-the-application)
 
 ### Run the application using your custom configuration
 

--- a/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
+++ b/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
@@ -32,9 +32,9 @@ public class FuzzyInferenceSystemInitializer {
         String fclRulesFilePath = applicationScenarioConfiguration.getFclRulesFilePath();
 
         // Try external file system
-        File externalFuzzyRuleResourceUrl = new File(fclRulesFilePath);
-        if (externalFuzzyRuleResourceUrl.exists()) {
-            return parseFclFile(externalFuzzyRuleResourceUrl.getPath());
+        File externalFuzzyRuleFile = new File(fclRulesFilePath);
+        if (externalFuzzyRuleFile.exists()) {
+            return parseFclFile(externalFuzzyRuleFile.getPath());
         }
 
         // Then try classpath resources


### PR DESCRIPTION
closes #25 

This MR adds instructions for running a custom scenario.

The changes were made:

- `README.md`: added the instructions on how to run the custom scenario
- `FuzzyInferenceSystemInitializer.java`: fixed the file path handling for the .fcl file. When running with a custom configuration, the `.jar` uses the .fcl file path provided as a File object.