### PR TITLE
Introduce GitHub Actions for Java build and release processes

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -2,7 +2,7 @@ name: Java CI with Maven and Release Artifact
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "*" ]
   pull_request:
     branches: [ "main" ]
   release:
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      version: ${{ steps.extract_version.outputs.version }}
-      artifactId: ${{ steps.extract_artifactId.outputs.artifactId }}
+      artifactId: ${{ steps.extract-metadata.outputs.artifactId }}
+      version: ${{ steps.extract-metadata.outputs.version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -31,34 +31,33 @@ jobs:
           cache: maven
 
       - name: Build with Maven
-        run: mvn -B clean install
+        run: mvn -B clean verify
 
-      - name: Extract project version
-        id: extract_version
-        run: |
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Extract artifactID
-        id: extract_artifactId
+      - name: Extract project version and artifactId (Release Only)
+        if: github.event_name == 'release'
+        id: extract-metadata
         run: |
           ARTIFACT_ID=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "artifactId=$ARTIFACT_ID" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Upload JAR
+      - name: Upload JAR (Release Only)
+        if: github.event_name == 'release'
         uses: actions/upload-artifact@v4
         with:
-          name: java-artifact
-          path: target/${{ steps.extract_artifactId.outputs.artifactId }}-${{ steps.extract_version.outputs.version }}.jar
+          name: release-jar
+          path: target/${{ steps.extract-metadata.outputs.artifactId }}-${{ steps.extract-metadata.outputs.version }}.jar
 
   release:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'release'
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Download JAR
+        uses: actions/download-artifact@v4
         with:
-          name: java-artifact
+          name: release-jar
           path: target
 
       - name: Upload Release Asset

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "*" ]
   release:
     types: [ released ]
 

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -1,4 +1,4 @@
-name: Java CI with Maven
+name: Java CI with Maven and Release Artifact
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ "main" ]
   release:
-    types: [ published ]
+    types: [ released ]
 
 permissions:
   contents: write
@@ -15,15 +15,15 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     outputs:
       version: ${{ steps.extract_version.outputs.version }}
+      artifactId: ${{ steps.extract_artifactId.outputs.artifactId }}
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 23
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           java-version: '23'
@@ -39,13 +39,19 @@ jobs:
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Extract artifactID
+        id: extract_artifactId
+        run: |
+          ARTIFACT_ID=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
+          echo "artifactId=$ARTIFACT_ID" >> $GITHUB_OUTPUT
+
       - name: Upload JAR
         uses: actions/upload-artifact@v4
         with:
           name: java-artifact
-          path: target/sliding-work-sharing-${{ steps.extract_version.outputs.version }}.jar
+          path: target/${{ steps.extract_artifactId.outputs.artifactId }}-${{ steps.extract_version.outputs.version }}.jar
 
-  publish:
+  release:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'release'
@@ -58,6 +64,6 @@ jobs:
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v2
         with:
-          files: target/sliding-work-sharing-${{ needs.build.outputs.version }}.jar
+          files: target/${{ needs.build.outputs.artifactId }}-${{ needs.build.outputs.version }}.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -1,0 +1,23 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 23
+        uses: actions/setup-java@v4
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -5,11 +5,21 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  release:
+    types: [ published ]
+
+permissions:
+  contents: write
+  actions: read
+  checks: write
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.extract_version.outputs.version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -19,5 +29,35 @@ jobs:
           java-version: '23'
           distribution: 'temurin'
           cache: maven
+
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: mvn -B clean install
+
+      - name: Extract project version
+        id: extract_version
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Upload JAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: java-artifact
+          path: target/sliding-work-sharing-${{ steps.extract_version.outputs.version }}.jar
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'release'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: java-artifact
+          path: target
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/sliding-work-sharing-${{ needs.build.outputs.version }}.jar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This MR includes the two GitHub actions

1. Java Build 
  - it is checking the `mvn clean install`

2. Publish Java Package 
  - It releases a downloadable JAR on "Create new Release" https://github.com/AI4WORK-Project/sliding-work-sharing/releases (manual process). 
  Note: It is recommended that, create a new "tag" and, based on this "tag," create a "new Release."