### PR TITLE
Updated release type in github-ci.yml

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ "*" ]
   release:
-    types: [ released ]
+    types: [ created ]
 
 permissions:
   contents: write


### PR DESCRIPTION
Changed release type so that now a "release" also triggers the "release job" of the workflow (see the log of the first run at https://github.com/AI4WORK-Project/sliding-work-sharing/actions/runs/14759142967).
