### PR TITLE
fix: Default applicarion scenario configuration is not running

### DIFF
--- a/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
+++ b/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
@@ -10,8 +10,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.net.URL;
+import java.io.InputStream;
 
 @Configuration
 @RequiredArgsConstructor
@@ -34,22 +35,22 @@ public class FuzzyInferenceSystemInitializer {
         // Try external file system
         File externalFuzzyRuleFile = new File(fclRulesFilePath);
         if (externalFuzzyRuleFile.exists()) {
-            return parseFclFile(externalFuzzyRuleFile.getPath());
+            return parseFclFile(new FileInputStream(externalFuzzyRuleFile), fclRulesFilePath);
         }
 
         // Then try classpath resources
-        URL internalFuzzyRuleResourceUrl = getClass().getClassLoader().getResource(fclRulesFilePath);
-        if (internalFuzzyRuleResourceUrl != null) {
-            return parseFclFile(internalFuzzyRuleResourceUrl.getPath());
+        InputStream internalFuzzyRuleResourceFile = getClass().getClassLoader().getResourceAsStream(fclRulesFilePath);
+        if (internalFuzzyRuleResourceFile != null) {
+            return parseFclFile(internalFuzzyRuleResourceFile, fclRulesFilePath);
         }
 
         throw new FileNotFoundException("Fuzzy Control Language (FCL) file not found: " + fclRulesFilePath);
     }
 
-    private static FIS parseFclFile(String fclRulesFilePath) {
+    private static FIS parseFclFile(InputStream inputStream, String fclRulesFilePath) {
         try {
             logger.debug("Initializing a Fuzzy Inference System (FIS) based on the FCL file: " + fclRulesFilePath);
-            return FIS.load(fclRulesFilePath);
+            return FIS.load(inputStream, true);
         } catch (Exception exception) {
             throw new InvalidFclFileException("Failed to parse Fuzzy Control Language (FCL) file: " + fclRulesFilePath, exception);
         }

--- a/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
+++ b/src/main/java/eu/ai4work/sws/config/FuzzyInferenceSystemInitializer.java
@@ -31,28 +31,28 @@ public class FuzzyInferenceSystemInitializer {
     @Bean(name = "fuzzyInferenceSystem")
     public FIS initializeFuzzyInferenceSystem() throws FileNotFoundException, InvalidFclFileException {
         String fclRulesFilePath = applicationScenarioConfiguration.getFclRulesFilePath();
+        logger.info("Initializing a Fuzzy Inference System (FIS) from FCL file: " + fclRulesFilePath);
 
         // Try external file system
         File externalFuzzyRuleFile = new File(fclRulesFilePath);
         if (externalFuzzyRuleFile.exists()) {
-            return parseFclFile(new FileInputStream(externalFuzzyRuleFile), fclRulesFilePath);
+            return parseFclFile(new FileInputStream(externalFuzzyRuleFile));
         }
 
         // Then try classpath resources
         InputStream internalFuzzyRuleResourceFile = getClass().getClassLoader().getResourceAsStream(fclRulesFilePath);
         if (internalFuzzyRuleResourceFile != null) {
-            return parseFclFile(internalFuzzyRuleResourceFile, fclRulesFilePath);
+            return parseFclFile(internalFuzzyRuleResourceFile);
         }
 
         throw new FileNotFoundException("Fuzzy Control Language (FCL) file not found: " + fclRulesFilePath);
     }
 
-    private static FIS parseFclFile(InputStream inputStream, String fclRulesFilePath) {
+    private static FIS parseFclFile(InputStream inputStream) {
         try {
-            logger.debug("Initializing a Fuzzy Inference System (FIS) based on the FCL file: " + fclRulesFilePath);
             return FIS.load(inputStream, true);
         } catch (Exception exception) {
-            throw new InvalidFclFileException("Failed to parse Fuzzy Control Language (FCL) file: " + fclRulesFilePath, exception);
+            throw new InvalidFclFileException("Failed to parse Fuzzy Control Language (FCL) file: ", exception);
         }
     }
 }


### PR DESCRIPTION
closes #39 

In the previuos version the `return parseFclFile(externalFuzzyRuleFile.getPath());
` and `return parseFclFile(internalFuzzyRuleResourceUrl.getPath());` in the `FuzzyInferenceSystemInitializer ` class assumes the FCL file accessible via file system path, which does not work inside a JAR. 

Using `InputStream` helped to read the contents of a file (path) and the resources inside a JAR.