### PR TITLE
Updated lombok to latest version, to fix build error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <maven.compiler.source>23</maven.compiler.source>
         <maven.compiler.target>23</maven.compiler.target>
         <java.version>23</java.version>
-        <lombok.version>1.18.36</lombok.version>
+        <lombok.version>1.18.46</lombok.version>
         <jFuzzyLogic.version>2016-07-04</jFuzzyLogic.version>
     </properties>
 


### PR DESCRIPTION
Could not build previous version (using Java 26 compiler). Internet search based on error messages pointed to lombok issues, and an update to the latest version fixed the build issue.