### PR TITLE
build and publish the docker image in github action added

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .git
 .github
-target
-*.jar
-README.md
+target/*
+!target/*.jar

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -55,7 +55,7 @@ jobs:
             --push \
             --file ./Dockerfile \
             --build-arg SWS_VERSION=${IMAGE_VERSION} \
-            --tag "${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
+            --tag "${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
             .
 
       - name: Upload release JAR

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Define SWS version in GITHUB_ENV
         run: |
-          RELEASE_REF_NAME_OR_LATEST ="${{ github.event_name == 'release' && github.ref_name || 'latest' }}"
+          RELEASE_REF_NAME_OR_LATEST="${{ github.event_name == 'release' && github.ref_name || 'latest' }}"
           echo "SWS_VERSION=${RELEASE_REF_NAME_OR_LATEST#v}" >> "$GITHUB_ENV"
 
       - name: Set version for Maven build

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -55,7 +55,7 @@ jobs:
             --push \
             --file ./Dockerfile \
             --build-arg SWS_VERSION=${SWS_VERSION} \
-            --tag "${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
+            --tag "${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}:${SWS_VERSION}" \
             .
 
       - name: Upload release JAR

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -55,7 +55,8 @@ jobs:
           docker buildx build \
             --push \
             --file ./Dockerfile \
-            --tag "${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
+            --build-arg SWS_VERSION=${IMAGE_VERSION} \
+            --tag "${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
             .
 
       - name: Upload release JAR

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -3,12 +3,10 @@ name: Java CI with Maven and Release Artifact
 on:
   push:
     branches: ["**"]
-
   pull_request:
     branches: ["**"]
-
   release:
-    types: [created]
+    types: [ created ]
 
 env:
   REGISTRY: ghcr.io
@@ -40,72 +38,37 @@ jobs:
       - name: Extract project metadata
         id: extract-metadata
         run: |
-          ARTIFACT_ID=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "artifactId=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)" >> "$GITHUB_OUTPUT"
+          echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
 
-          echo "artifactId=$ARTIFACT_ID" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-          echo "Artifact ID: $ARTIFACT_ID"
-          echo "Version: $VERSION"
-
-      # Only for a GitHub Release:
-      # Make sure the release tag and pom.xml version are the same.
-      #
-      # Example:
-      # Release tag: v1.2.0
-      # pom.xml:     1.2.0
       - name: Validate release version
         if: github.event_name == 'release'
         run: |
           RELEASE_VERSION="${{ github.event.release.tag_name }}"
-          RELEASE_VERSION="${RELEASE_VERSION#v}"
-
-          POM_VERSION="${{ steps.extract-metadata.outputs.version }}"
-
-          echo "Release version: $RELEASE_VERSION"
-          echo "POM version:     $POM_VERSION"
-
-          if [ "$RELEASE_VERSION" != "$POM_VERSION" ]; then
-            echo "ERROR: Release version does not match pom.xml version."
-            exit 1
-          fi
+          [ "${RELEASE_VERSION#v}" = "${{ steps.metadata.outputs.version }}" ]
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
-      - name: Log in to GHCR
+      - name: Log in to registry
+        if: github.event_name != 'pull_request'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.REGISTRY }} -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and push the container image
         if: github.event_name != 'pull_request'
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | \
-          docker login ${{ env.REGISTRY }} \
-            -u "${{ github.actor }}" \
-            --password-stdin
-
-      - name: Build and push Docker image
-        if: github.event_name != 'pull_request'
-        run: |
-          IMAGE_NAME="${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}"
-
-          if [ "${{ github.event_name }}" = "release" ]; then
-            IMAGE_VERSION="${{ steps.extract-metadata.outputs.version }}"
-          else
-            IMAGE_VERSION="latest"
-          fi
-
-          echo "Docker image: ${IMAGE_NAME}:${IMAGE_VERSION}"
-          echo "SWS version: ${{ steps.extract-metadata.outputs.version }}"
+          IMAGE_VERSION="${{ github.event_name == 'release' && steps.extract-metadata.outputs.version || 'latest' }}"
 
           docker buildx build \
             --push \
             --file ./Dockerfile \
             --build-arg SWS_VERSION="${{ steps.extract-metadata.outputs.version }}" \
-            --tag "${IMAGE_NAME}:${IMAGE_VERSION}" \
+            --tag "${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
             .
 
       - name: Upload JAR (Release Only)
         if: github.event_name == 'release'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-jar
           path: target/${{ steps.extract-metadata.outputs.artifactId }}-${{ steps.extract-metadata.outputs.version }}.jar
@@ -116,7 +79,7 @@ jobs:
     if: github.event_name == 'release'
     steps:
       - name: Download JAR
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-jar
           path: target

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -2,16 +2,20 @@ name: Java CI with Maven and Release Artifact
 
 on:
   push:
-    branches: [ "*" ]
+    branches: ["**"]
+
   pull_request:
-    branches: [ "*" ]
+    branches: ["**"]
+
   release:
-    types: [ created ]
+    types: [created]
+
+env:
+  REGISTRY: ghcr.io
 
 permissions:
   contents: write
-  actions: read
-  checks: write
+  packages: write
 
 jobs:
   build:
@@ -41,6 +45,57 @@ jobs:
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "artifactId=$ARTIFACT_ID" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      # Only for a GitHub Release:
+      # Make sure the release tag and pom.xml version are the same.
+      #
+      # Example:
+      # Release tag: v1.2.0
+      # pom.xml:     1.2.0
+      - name: Validate release version
+        if: github.event_name == 'release'
+        run: |
+          RELEASE_VERSION="${{ github.event.release.tag_name }}"
+          RELEASE_VERSION="${RELEASE_VERSION#v}"
+
+          POM_VERSION="${{ steps.extract-metadata.outputs.version }}"
+
+          echo "Release version: $RELEASE_VERSION"
+          echo "POM version:     $POM_VERSION"
+
+          if [ "$RELEASE_VERSION" != "$POM_VERSION" ]; then
+            echo "ERROR: Release version does not match pom.xml version."
+            exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+          docker login ${{ env.REGISTRY }} \
+            -u "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Build and push Docker image
+        if: github.event_name != 'pull_request'
+        run: |
+          IMAGE_NAME="${{ env.REGISTRY }}/${{ github.repository }}"
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+            IMAGE_VERSION="${{ steps.extract-metadata.outputs.version }}"
+          else
+            IMAGE_VERSION="latest"
+          fi
+
+          docker buildx build \
+            --push \
+            --file ./Dockerfile \
+            --build-arg SWS_VERSION="${{ steps.extract-metadata.outputs.version }}" \
+            --tag "${IMAGE_NAME}:${IMAGE_VERSION}" \
+            .
 
       - name: Upload JAR (Release Only)
         if: github.event_name == 'release'

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -19,33 +19,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    outputs:
-      artifactId: ${{ steps.extract-metadata.outputs.artifactId }}
-      version: ${{ steps.extract-metadata.outputs.version }}
-
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.7.0
         with:
-          java-version: '25'
+          java-version: '25.0.3'
           distribution: 'temurin'
           cache: maven
 
       - name: Build with Maven
         run: mvn -B clean verify
-
-      - name: Extract project metadata
-        id: extract-metadata
-        run: |
-          echo "artifactId=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)" >> "$GITHUB_OUTPUT"
-          echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
-
-      - name: Validate release version
-        if: github.event_name == 'release'
-        run: |
-          RELEASE_VERSION="${{ github.event.release.tag_name }}"
-          [ "${RELEASE_VERSION#v}" = "${{ steps.metadata.outputs.version }}" ]
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -57,36 +43,24 @@ jobs:
       - name: Build and push the container image
         if: github.event_name != 'pull_request'
         run: |
-          IMAGE_VERSION="${{ github.event_name == 'release' && steps.extract-metadata.outputs.version || 'latest' }}"
+          IMAGE_VERSION="${{ github.event_name == 'release' && github.ref_name || 'latest' }}"
+          IMAGE_VERSION="${IMAGE_VERSION#v}"
 
           docker buildx build \
             --push \
             --file ./Dockerfile \
-            --build-arg SWS_VERSION="${{ steps.extract-metadata.outputs.version }}" \
             --tag "${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
             .
 
-      - name: Upload JAR (Release Only)
+      - name: Release JAR
         if: github.event_name == 'release'
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-jar
-          path: target/${{ steps.extract-metadata.outputs.artifactId }}-${{ steps.extract-metadata.outputs.version }}.jar
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          cp target/sliding-work-sharing.jar target/sliding-work-sharing-${VERSION}.jar
 
-  release:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'release'
-    steps:
-      - name: Download JAR
-        uses: actions/download-artifact@v8
+      - name: Upload release JAR
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v3
         with:
-          name: release-jar
-          path: target
-
-      - name: Upload Release Asset
-        uses: softprops/action-gh-release@v2
-        with:
-          files: target/${{ needs.build.outputs.artifactId }}-${{ needs.build.outputs.version }}.jar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          files: target/sliding-work-sharing-*.jar

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -31,9 +31,8 @@ jobs:
           cache: maven
 
       - name: Set version from tag
-        if: github.event_name == 'release'
         run: |
-          TAG_NAME="${{ github.ref_name }}"
+          TAG_NAME="${{ github.event_name == 'release' && github.ref_name || 'latest' }}"
           mvn versions:set -DnewVersion="${TAG_NAME#v}"
 
       - name: Build with Maven

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -58,4 +58,4 @@ jobs:
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v3
         with:
-          files: target/sliding-work-sharing-${SWS_VERSION}.jar
+          files: target/sliding-work-sharing-*.jar

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -37,14 +37,17 @@ jobs:
       - name: Build with Maven
         run: mvn -B clean verify
 
-      - name: Extract project version and artifactId (Release Only)
-        if: github.event_name == 'release'
+      - name: Extract project metadata
         id: extract-metadata
         run: |
           ARTIFACT_ID=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "artifactId=$ARTIFACT_ID" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          echo "artifactId=$ARTIFACT_ID" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          echo "Artifact ID: $ARTIFACT_ID"
+          echo "Version: $VERSION"
 
       # Only for a GitHub Release:
       # Make sure the release tag and pom.xml version are the same.
@@ -82,13 +85,16 @@ jobs:
       - name: Build and push Docker image
         if: github.event_name != 'pull_request'
         run: |
-          IMAGE_NAME="${{ env.REGISTRY }}/${{ github.repository }}"
+          IMAGE_NAME="${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}"
 
           if [ "${{ github.event_name }}" = "release" ]; then
             IMAGE_VERSION="${{ steps.extract-metadata.outputs.version }}"
           else
             IMAGE_VERSION="latest"
           fi
+
+          echo "Docker image: ${IMAGE_NAME}:${IMAGE_VERSION}"
+          echo "SWS version: ${{ steps.extract-metadata.outputs.version }}"
 
           docker buildx build \
             --push \

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -30,6 +30,12 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
+      - name: Set version from tag
+        if: github.event_name == 'release'
+        run: |
+          TAG_NAME="${{ github.ref_name }}"
+          mvn versions:set -DnewVersion="${TAG_NAME#v}" -DprocessAllModules
+
       - name: Build with Maven
         run: mvn -B clean verify
 
@@ -51,13 +57,6 @@ jobs:
             --file ./Dockerfile \
             --tag "${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
             .
-
-      - name: Release JAR
-        if: github.event_name == 'release'
-        run: |
-          VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#v}"
-          cp target/sliding-work-sharing.jar target/sliding-work-sharing-${VERSION}.jar
 
       - name: Upload release JAR
         if: github.event_name == 'release'

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -34,7 +34,7 @@ jobs:
         if: github.event_name == 'release'
         run: |
           TAG_NAME="${{ github.ref_name }}"
-          mvn versions:set -DnewVersion="${TAG_NAME#v}" -DprocessAllModules
+          mvn versions:set -DnewVersion="${TAG_NAME#v}"
 
       - name: Build with Maven
         run: mvn -B clean verify

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -3,8 +3,6 @@ name: Java CI with Maven and Release Artifact
 on:
   push:
     branches: ["**"]
-  pull_request:
-    branches: ["**"]
   release:
     types: [ created ]
 
@@ -45,11 +43,9 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to registry
-        if: github.event_name != 'pull_request'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.REGISTRY }} -u "${{ github.actor }}" --password-stdin
 
       - name: Build and push the container image
-        if: github.event_name != 'pull_request'
         run: |
           docker buildx build \
             --push \

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -30,10 +30,13 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Set version from tag
+      - name: Define SWS version in GITHUB_ENV
         run: |
-          TAG_NAME="${{ github.event_name == 'release' && github.ref_name || 'latest' }}"
-          mvn versions:set -DnewVersion="${TAG_NAME#v}"
+          RELEASE_REF_NAME_OR_LATEST ="${{ github.event_name == 'release' && github.ref_name || 'latest' }}"
+          echo "SWS_VERSION=${RELEASE_REF_NAME_OR_LATEST#v}" >> "$GITHUB_ENV"
+
+      - name: Set version for Maven build
+        run: mvn versions:set -DnewVersion="${SWS_VERSION}"
 
       - name: Build with Maven
         run: mvn -B clean verify
@@ -48,13 +51,10 @@ jobs:
       - name: Build and push the container image
         if: github.event_name != 'pull_request'
         run: |
-          IMAGE_VERSION="${{ github.event_name == 'release' && github.ref_name || 'latest' }}"
-          IMAGE_VERSION="${IMAGE_VERSION#v}"
-
           docker buildx build \
             --push \
             --file ./Dockerfile \
-            --build-arg SWS_VERSION=${IMAGE_VERSION} \
+            --build-arg SWS_VERSION=${SWS_VERSION} \
             --tag "${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
             .
 
@@ -62,4 +62,4 @@ jobs:
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v3
         with:
-          files: target/sliding-work-sharing-*.jar
+          files: target/sliding-work-sharing-${SWS_VERSION}.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,14 @@
 # Create the application image
 FROM eclipse-temurin:25-jre
 
-# Version of Sliding Work Sharing
-ARG SWS_VERSION=1.0.0
-
 LABEL org.opencontainers.image.title="Sliding Work Sharing"
 LABEL org.opencontainers.image.description="Sliding Work Sharing Management Component of the AI4Work project"
 LABEL org.opencontainers.image.source="https://github.com/AI4WORK-Project/sliding-work-sharing"
-LABEL org.opencontainers.image.version="${SWS_VERSION}"
 
 WORKDIR /app
 
 # Copy the JAR produced by Maven
-COPY target/sliding-work-sharing-${SWS_VERSION}.jar /app/sliding-work-sharing.jar
+COPY target/sliding-work-sharing.jar /app/sliding-work-sharing.jar
 
 # Create a standard directory for custom YAML configuration and FCL rule files
 # when starting the container, custom files can be mount into this directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,10 @@
 # syntax=docker/dockerfile:1
 
-# Version of the published Sliding Work Sharing release
-ARG SWS_VERSION=1.0.0
-
-# Download the published Sliding Work Sharing JAR from GitHub
-FROM curlimages/curl:8.21.0 AS sws-release-downloader
-
-ARG SWS_VERSION
-
-RUN curl --fail --location --silent --show-error \
-    "https://github.com/AI4WORK-Project/sliding-work-sharing/releases/download/v${SWS_VERSION}/sliding-work-sharing-${SWS_VERSION}.jar" \
-    --output /tmp/sliding-work-sharing.jar
-
 # Create the application image
 FROM eclipse-temurin:25-jre
-ARG SWS_VERSION
+
+# Version of Sliding Work Sharing
+ARG SWS_VERSION=1.0.1
 
 LABEL org.opencontainers.image.title="Sliding Work Sharing"
 LABEL org.opencontainers.image.description="Sliding Work Sharing Management Component of the AI4Work project"
@@ -23,7 +13,8 @@ LABEL org.opencontainers.image.version="${SWS_VERSION}"
 
 WORKDIR /app
 
-COPY --from=sws-release-downloader /tmp/sliding-work-sharing.jar /app/sliding-work-sharing.jar
+# Copy the JAR produced by Maven
+COPY target/sliding-work-sharing-${SWS_VERSION}.jar /app/sliding-work-sharing.jar
 
 # Create a standard directory for custom YAML configuration and FCL rule files
 # when starting the container, custom files can be mount into this directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,17 @@
 # Create the application image
 FROM eclipse-temurin:25-jre
 
+ARG SWS_VERSION
+
 LABEL org.opencontainers.image.title="Sliding Work Sharing"
 LABEL org.opencontainers.image.description="Sliding Work Sharing Management Component of the AI4Work project"
 LABEL org.opencontainers.image.source="https://github.com/AI4WORK-Project/sliding-work-sharing"
+LABEL org.opencontainers.image.version=${SWS_VERSION}
 
 WORKDIR /app
 
 # Copy the JAR produced by Maven
-COPY target/sliding-work-sharing-*.jar /app/
+COPY target/sliding-work-sharing-${SWS_VERSION}.jar /app/
 
 # Create a standard directory for custom YAML configuration and FCL rule files
 # when starting the container, custom files can be mount into this directory
@@ -18,4 +21,4 @@ RUN mkdir -p /config
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java -jar /app/sliding-work-sharing-*.jar"]
+ENTRYPOINT ["sh", "-c", "java -jar /app/sliding-work-sharing-${SWS_VERSION}.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@
 FROM eclipse-temurin:25-jre
 
 ARG SWS_VERSION
-ENV SWS_VERSION=${SWS_VERSION}
 
 LABEL org.opencontainers.image.title="Sliding Work Sharing"
 LABEL org.opencontainers.image.description="Sliding Work Sharing Management Component of the AI4Work project"
@@ -14,7 +13,7 @@ LABEL org.opencontainers.image.version=${SWS_VERSION}
 WORKDIR /app
 
 # Copy the JAR produced by Maven
-COPY target/sliding-work-sharing-${SWS_VERSION}.jar /app/
+COPY target/sliding-work-sharing-${SWS_VERSION}.jar /app/sliding-work-sharing.jar
 
 # Create a standard directory for custom YAML configuration and FCL rule files
 # when starting the container, custom files can be mount into this directory
@@ -22,4 +21,4 @@ RUN mkdir -p /config
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "exec java -jar /app/sliding-work-sharing-${SWS_VERSION}.jar"]
+ENTRYPOINT ["java", "-jar", "/app/sliding-work-sharing.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM eclipse-temurin:25-jre
 
 # Version of Sliding Work Sharing
-ARG SWS_VERSION=1.0.1
+ARG SWS_VERSION=1.0.0
 
 LABEL org.opencontainers.image.title="Sliding Work Sharing"
 LABEL org.opencontainers.image.description="Sliding Work Sharing Management Component of the AI4Work project"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 FROM eclipse-temurin:25-jre
 
 ARG SWS_VERSION
+ENV SWS_VERSION=${SWS_VERSION}
 
 LABEL org.opencontainers.image.title="Sliding Work Sharing"
 LABEL org.opencontainers.image.description="Sliding Work Sharing Management Component of the AI4Work project"
@@ -21,4 +22,4 @@ RUN mkdir -p /config
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "/app/sliding-work-sharing-*.jar"]
+ENTRYPOINT ["sh", "-c", "exec java -jar /app/sliding-work-sharing-${SWS_VERSION}.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL org.opencontainers.image.source="https://github.com/AI4WORK-Project/slidin
 WORKDIR /app
 
 # Copy the JAR produced by Maven
-COPY target/sliding-work-sharing.jar /app/sliding-work-sharing.jar
+COPY target/sliding-work-sharing-*.jar /app/
 
 # Create a standard directory for custom YAML configuration and FCL rule files
 # when starting the container, custom files can be mount into this directory
@@ -18,4 +18,4 @@ RUN mkdir -p /config
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "/app/sliding-work-sharing.jar"]
+ENTRYPOINT ["sh", "-c", "java -jar /app/sliding-work-sharing-*.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN mkdir -p /config
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java -jar /app/sliding-work-sharing-${SWS_VERSION}.jar"]
+ENTRYPOINT ["sh", "-c", "java -jar /app/sliding-work-sharing-*.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN mkdir -p /config
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java -jar /app/sliding-work-sharing-*.jar"]
+ENTRYPOINT ["java", "-jar", "/app/sliding-work-sharing-*.jar"]

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ To build and run the Sliding Work Sharing, the following software is required:
 
 **Docker**: Docker Desktop or Docker Engine (https://www.docker.com/get-started/)
 
-### 2. Build the Docker image
+### 2. Pull the SWS Docker image
 
-Open a terminal in the project directory containing the `Dockerfile`, run:
+Open a terminal and pull the Docker image using the following command:
 
 ```bash
-docker build -t sliding-work-sharing .
+docker pull ghcr.io/ai4work-project/sliding-work-sharing:1.1.0
 ```
 
 ### 3. Start the Application (using the Default Configuration for Testing)
@@ -29,7 +29,7 @@ docker build -t sliding-work-sharing .
 Run the following command to start the application using the built container image:
 
 ```bash
-docker run --rm -p 8080:8080 sliding-work-sharing
+docker run --rm -p 8080:8080 ghcr.io/ai4work-project/sliding-work-sharing:1.1.0
 ```
 
 The application will start and listen on port `8080` by default.
@@ -144,7 +144,7 @@ Use the following instructions to mount your config directory inside the Docker 
 docker run --rm \
   -p 8080:8080 \
   --mount type=bind,source="<PATH_TO_YOUR_CONFIG_DIRECTORY_ON_THE_HOST_MACHINE>",target=/config,readonly \
-  sliding-work-sharing \
+  ghcr.io/ai4work-project/sliding-work-sharing:1.1.0 \
   --spring.config.location=file:/config/application-{your-configuration-name}.yml
 ```
 
@@ -159,7 +159,7 @@ For example:
 docker run --rm \
   -p 8080:8080 \
   --mount type=bind,source="/home/user/sws-config",target=/config,readonly \
-  sliding-work-sharing \
+  ghcr.io/ai4work-project/sliding-work-sharing:1.1.0 \
   --spring.config.location=file:/config/application-sws-scenario.yml
 ```
 
@@ -169,7 +169,7 @@ docker run --rm \
 docker run --rm `
   -p 8080:8080 `
   --mount type=bind,source="<PATH_TO_YOUR_CONFIG_DIRECTORY_ON_THE_HOST_MACHINE>",target=/config,readonly `
-  sliding-work-sharing `
+  ghcr.io/ai4work-project/sliding-work-sharing:1.1.0 `
   --spring.config.location=file:/config/application-{your-configuration-name}.yml
 ```
 
@@ -184,7 +184,7 @@ For example:
 docker run --rm `
   -p 8080:8080 `
   --mount type=bind,source="C:\Users\YourName\sws-config",target=/config,readonly `
-  sliding-work-sharing `
+  ghcr.io/ai4work-project/sliding-work-sharing:1.1.0 `
   --spring.config.location=file:/config/application-sws-scenario.yml
 ```
 
@@ -233,7 +233,7 @@ located [here](src/main/resources/rules/TruckSchedulingSlidingDecisionRules.fcl)
 To start the application and run the logistics scenario, use the following command:
 
 ```bash
-docker run --rm -p 8080:8080 sliding-work-sharing --spring.profiles.active=logistics
+docker run --rm -p 8080:8080 ghcr.io/ai4work-project/sliding-work-sharing:1.1.0 --spring.profiles.active=logistics
 ```
 
 ##### Example Request
@@ -327,7 +327,7 @@ located [here](src/main/resources/rules/AgricultureSchedulingSlidingDecisionRule
 To start the application and run the agriculture scenario, use the following command:
 
 ```bash
-docker run --rm -p 8080:8080 sliding-work-sharing --spring.profiles.active=agriculture
+docker run --rm -p 8080:8080 ghcr.io/ai4work-project/sliding-work-sharing:1.1.0 --spring.profiles.active=agriculture
 ```
 
 ##### Example Request
@@ -427,7 +427,7 @@ located [here](src/main/resources/rules/ConstructionRobotAssistanceDecisionRules
 To start the application and run the construction scenario, use the following command:
 
 ```bash
-docker run --rm -p 8080:8080 sliding-work-sharing --spring.profiles.active=construction
+docker run --rm -p 8080:8080 ghcr.io/ai4work-project/sliding-work-sharing:1.1.0 --spring.profiles.active=construction
 ```
 
 ##### Example Request

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>eu.ai4work</groupId>
     <artifactId>sliding-work-sharing</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-beta</version>
     <name>Sliding Work Sharing</name>
     <description>Sliding Work Sharing Management Component of the AI4Work project</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     </parent>
     <groupId>eu.ai4work</groupId>
     <artifactId>sliding-work-sharing</artifactId>
-    <name>Sliding Work Sharing</name>
     <version>1.0.0</version>
+    <name>Sliding Work Sharing</name>
     <description>Sliding Work Sharing Management Component of the AI4Work project</description>
 
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <groupId>eu.ai4work</groupId>
     <artifactId>sliding-work-sharing</artifactId>
     <name>Sliding Work Sharing</name>
+    <version>1.0.0</version>
     <description>Sliding Work Sharing Management Component of the AI4Work project</description>
 
     <packaging>jar</packaging>
@@ -73,7 +74,6 @@
     </dependencies>
 
     <build>
-        <finalName>sliding-work-sharing</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,6 @@
     </parent>
     <groupId>eu.ai4work</groupId>
     <artifactId>sliding-work-sharing</artifactId>
-    <version>1.0.0</version>
     <name>Sliding Work Sharing</name>
     <description>Sliding Work Sharing Management Component of the AI4Work project</description>
 
@@ -74,6 +73,7 @@
     </dependencies>
 
     <build>
+        <finalName>sliding-work-sharing</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION

In the PR following is included: 

in the CI pipeline (Github Actions):

- take the version number from the tag/release
- set that version number in the pom via mvn versions:set (only release)
- Build with Maven
- Build and push the container image
   - release - release name taken from the tag (release only)
   - pull, commit, etc - release name is "latest"
- then publish that jar (relese only)

While release event the following will be done (based on the tag name for example `1.2.3` 
  
  - a jar file with `1.2.3` in the name
  - the `pom.xml` inside that jar file would contain `<version>1.2.3</version>`
  - the container image would contain the `jar` file and would also be tagged `1.2.3`
  
Build a container image can be found at: https://github.com/AI4WORK-Project/sliding-work-sharing/pkgs/container/sliding-work-sharing