### PR TITLE
minor improvements to Dockerfile and Github-CI config

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -55,7 +55,7 @@ jobs:
             --push \
             --file ./Dockerfile \
             --build-arg SWS_VERSION=${IMAGE_VERSION} \
-            --tag "${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
+            --tag "${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
             .
 
       - name: Upload release JAR

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Define SWS version in GITHUB_ENV
         run: |
-          RELEASE_REF_NAME_OR_LATEST ="${{ github.event_name == 'release' && github.ref_name || 'latest' }}"
+          RELEASE_REF_NAME_OR_LATEST="${{ github.event_name == 'release' && github.ref_name || 'latest' }}"
           echo "SWS_VERSION=${RELEASE_REF_NAME_OR_LATEST#v}" >> "$GITHUB_ENV"
 
       - name: Set version for Maven build

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -55,7 +55,7 @@ jobs:
             --push \
             --file ./Dockerfile \
             --build-arg SWS_VERSION=${SWS_VERSION} \
-            --tag "${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
+            --tag "${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}:${SWS_VERSION}" \
             .
 
       - name: Upload release JAR

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -55,7 +55,8 @@ jobs:
           docker buildx build \
             --push \
             --file ./Dockerfile \
-            --tag "${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
+            --build-arg SWS_VERSION=${IMAGE_VERSION} \
+            --tag "${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
             .
 
       - name: Upload release JAR

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -31,9 +31,8 @@ jobs:
           cache: maven
 
       - name: Set version from tag
-        if: github.event_name == 'release'
         run: |
-          TAG_NAME="${{ github.ref_name }}"
+          TAG_NAME="${{ github.event_name == 'release' && github.ref_name || 'latest' }}"
           mvn versions:set -DnewVersion="${TAG_NAME#v}"
 
       - name: Build with Maven

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -3,8 +3,6 @@ name: Java CI with Maven and Release Artifact
 on:
   push:
     branches: ["**"]
-  pull_request:
-    branches: ["**"]
   release:
     types: [ created ]
 
@@ -45,11 +43,9 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to registry
-        if: github.event_name != 'pull_request'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.REGISTRY }} -u "${{ github.actor }}" --password-stdin
 
       - name: Build and push the container image
-        if: github.event_name != 'pull_request'
         run: |
           docker buildx build \
             --push \

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -30,10 +30,13 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Set version from tag
+      - name: Define SWS version in GITHUB_ENV
         run: |
-          TAG_NAME="${{ github.event_name == 'release' && github.ref_name || 'latest' }}"
-          mvn versions:set -DnewVersion="${TAG_NAME#v}"
+          RELEASE_REF_NAME_OR_LATEST ="${{ github.event_name == 'release' && github.ref_name || 'latest' }}"
+          echo "SWS_VERSION=${RELEASE_REF_NAME_OR_LATEST#v}" >> "$GITHUB_ENV"
+
+      - name: Set version for Maven build
+        run: mvn versions:set -DnewVersion="${SWS_VERSION}"
 
       - name: Build with Maven
         run: mvn -B clean verify
@@ -48,13 +51,10 @@ jobs:
       - name: Build and push the container image
         if: github.event_name != 'pull_request'
         run: |
-          IMAGE_VERSION="${{ github.event_name == 'release' && github.ref_name || 'latest' }}"
-          IMAGE_VERSION="${IMAGE_VERSION#v}"
-
           docker buildx build \
             --push \
             --file ./Dockerfile \
-            --build-arg SWS_VERSION=${IMAGE_VERSION} \
+            --build-arg SWS_VERSION=${SWS_VERSION} \
             --tag "${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" \
             .
 
@@ -62,4 +62,4 @@ jobs:
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v3
         with:
-          files: target/sliding-work-sharing-*.jar
+          files: target/sliding-work-sharing-${SWS_VERSION}.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,17 @@
 # Create the application image
 FROM eclipse-temurin:25-jre
 
+ARG SWS_VERSION
+
 LABEL org.opencontainers.image.title="Sliding Work Sharing"
 LABEL org.opencontainers.image.description="Sliding Work Sharing Management Component of the AI4Work project"
 LABEL org.opencontainers.image.source="https://github.com/AI4WORK-Project/sliding-work-sharing"
+LABEL org.opencontainers.image.version=${SWS_VERSION}
 
 WORKDIR /app
 
 # Copy the JAR produced by Maven
-COPY target/sliding-work-sharing-*.jar /app/
+COPY target/sliding-work-sharing-${SWS_VERSION}.jar /app/
 
 # Create a standard directory for custom YAML configuration and FCL rule files
 # when starting the container, custom files can be mount into this directory
@@ -18,4 +21,4 @@ RUN mkdir -p /config
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java -jar /app/sliding-work-sharing-*.jar"]
+ENTRYPOINT ["sh", "-c", "java -jar /app/sliding-work-sharing-${SWS_VERSION}.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@
 FROM eclipse-temurin:25-jre
 
 ARG SWS_VERSION
-ENV SWS_VERSION=${SWS_VERSION}
 
 LABEL org.opencontainers.image.title="Sliding Work Sharing"
 LABEL org.opencontainers.image.description="Sliding Work Sharing Management Component of the AI4Work project"
@@ -14,7 +13,7 @@ LABEL org.opencontainers.image.version=${SWS_VERSION}
 WORKDIR /app
 
 # Copy the JAR produced by Maven
-COPY target/sliding-work-sharing-${SWS_VERSION}.jar /app/
+COPY target/sliding-work-sharing-${SWS_VERSION}.jar /app/sliding-work-sharing.jar
 
 # Create a standard directory for custom YAML configuration and FCL rule files
 # when starting the container, custom files can be mount into this directory
@@ -22,4 +21,4 @@ RUN mkdir -p /config
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "exec java -jar /app/sliding-work-sharing-${SWS_VERSION}.jar"]
+ENTRYPOINT ["java", "-jar", "/app/sliding-work-sharing.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 FROM eclipse-temurin:25-jre
 
 ARG SWS_VERSION
+ENV SWS_VERSION=${SWS_VERSION}
 
 LABEL org.opencontainers.image.title="Sliding Work Sharing"
 LABEL org.opencontainers.image.description="Sliding Work Sharing Management Component of the AI4Work project"
@@ -21,4 +22,4 @@ RUN mkdir -p /config
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "/app/sliding-work-sharing-*.jar"]
+ENTRYPOINT ["sh", "-c", "exec java -jar /app/sliding-work-sharing-${SWS_VERSION}.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN mkdir -p /config
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java -jar /app/sliding-work-sharing-${SWS_VERSION}.jar"]
+ENTRYPOINT ["sh", "-c", "java -jar /app/sliding-work-sharing-*.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN mkdir -p /config
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java -jar /app/sliding-work-sharing-*.jar"]
+ENTRYPOINT ["java", "-jar", "/app/sliding-work-sharing-*.jar"]


### PR DESCRIPTION
Minor improvement suggestions to #57 
- avoid extra builds on pull requests
- define the SWS version number once and write it to github-env, so that it can be used by both maven build and docker build
- reverted the `ENTRYPOINT` to `["java" , "-jar" ... ]`, because otherwise it did not work anymore to pass a parameter like `--spring.config.location=...yml` to the JVM when running the docker image
